### PR TITLE
ユーザーモデルの制約追加（line_uid unique / family_group_id null許可）

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,7 @@
 class User < ApplicationRecord
-  belongs_to :family_group
+  # family_groupが無いユーザーも存在する仕様
+  belongs_to :family_group, optional: true
+
+  validates :line_uid, presence: true, uniqueness: true
+  validates :name, presence: true, length: { maximum: 50 }
 end

--- a/db/migrate/20251110021340_create_users.rb
+++ b/db/migrate/20251110021340_create_users.rb
@@ -4,9 +4,11 @@ class CreateUsers < ActiveRecord::Migration[7.2]
       t.string :name
       t.string :line_uid
       t.string :email
-      t.references :family_group, null: false, foreign_key: true
+      t.references :family_group, null: true, foreign_key: true
 
       t.timestamps
     end
+
+    add_index :users, :line_uid, unique: true
   end
 end


### PR DESCRIPTION
### 概要

LINEログインがユーザー識別の中心となるため、line_uid にユニーク制約を追加し、ログイン識別の仕組みを整備。

#### 作業手順

- line_uid にユニーク制約を追加
```
add_index :users, :line_uid, unique: true
```
- バリデーション追加
```
validates :name, presence: true
```
- family_group_id を null: true に変更（招待前のユーザーを許容）

- マイグレーション実行
```
rails db:migrate
```

#### 達成条件

- line_uid を使ってユーザーを一意に識別可能
- LINEログイン用の基礎モデルが完成