### PR TITLE
User モデルの制約（line_uid uniqueness）を修正

### DIFF
--- a/db/migrate/20251110021340_create_users.rb
+++ b/db/migrate/20251110021340_create_users.rb
@@ -5,10 +5,9 @@ class CreateUsers < ActiveRecord::Migration[7.2]
       t.string :line_uid
       t.string :email
       t.references :family_group, null: true, foreign_key: true
+      t.index :line_uid, unique: true
 
       t.timestamps
     end
-
-    add_index :users, :line_uid, unique: true
   end
 end

--- a/db/migrate/20251114081135_add_unique_index_to_users_line_uid.rb
+++ b/db/migrate/20251114081135_add_unique_index_to_users_line_uid.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToUsersLineUid < ActiveRecord::Migration[7.2]
+  def change
+    add_index :users, :line_uid, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_11_10_021357) do
+ActiveRecord::Schema[7.2].define(version: 2025_11_14_081135) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -92,6 +92,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_11_10_021357) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["family_group_id"], name: "index_users_on_family_group_id"
+    t.index ["line_uid"], name: "index_users_on_line_uid", unique: true
   end
 
   add_foreign_key "albums", "children"


### PR DESCRIPTION
### 概要
Userモデルにline_uidのユニーク制約を追加するため、
DB上の重複データを削除し、整合性を確保しました。

#### 行なったこと
- line_uidのunique index追加
- DBに存在していたline_uidの重複データを削除
- posts / photos / notifications の依存関係も整合性を保って削除
- Rubocopエラー解消