### PR TITLE
InviteTokenモデル作成と招待リンク発行

### DIFF
--- a/app/controllers/invite_tokens_controller.rb
+++ b/app/controllers/invite_tokens_controller.rb
@@ -1,0 +1,59 @@
+class InviteTokensController < ApplicationController
+  # 招待リンクの発行はログイン必須
+  before_action :require_login, only: :create
+  # 招待リンクを踏む側は未ログインの可能性があるのでスキップ
+  skip_before_action :require_login, only: :show
+
+  def show
+    invite = InviteToken.valid.find_by(token: params[:token])
+
+    return redirect_invalid_token unless invite
+
+    store_family_session(invite)
+    redirect_to root_path, notice: t('invite_tokens.accepted')
+  end
+
+  def create
+    return redirect_family_not_exist unless current_user.family_group
+
+    invite = create_invite_token
+    invite_url_full = build_invite_url(invite)
+
+    log_invite_url(invite_url_full)
+    invite_flash(invite_url_full)
+
+    redirect_back fallback_location: family_settings_path
+  end
+
+  private
+
+  def redirect_invalid_token
+    redirect_to root_path, alert: t('invite_tokens.invalid')
+  end
+
+  def store_family_session(invite)
+    session[:invite_family_group_id] = invite.family_group_id
+  end
+
+  def redirect_family_not_exist
+    redirect_back fallback_location: root_path,
+                  alert: t('invite_tokens.family_not_exist')
+  end
+
+  def create_invite_token
+    current_user.family_group.invite_tokens.create!
+  end
+
+  def build_invite_url(invite)
+    invite_url(invite.token)
+  end
+
+  def log_invite_url(url)
+    Rails.logger.info "INVITE URL: #{url}"
+  end
+
+  def invite_flash(url)
+    flash[:notice] = t('invite_tokens.issued')
+    flash.now[:invite_url] = url
+  end
+end

--- a/app/helpers/invite_tokens_helper.rb
+++ b/app/helpers/invite_tokens_helper.rb
@@ -1,0 +1,2 @@
+module InviteTokensHelper
+end

--- a/app/models/family_group.rb
+++ b/app/models/family_group.rb
@@ -3,6 +3,7 @@ class FamilyGroup < ApplicationRecord
   has_many :users, dependent: :nullify # 家族削除 → ユーザーは削除しない
   has_many :children, dependent: :destroy
   has_many :albums, dependent: :destroy
+  has_many :invite_tokens, dependent: :destroy
 
   # バリデーション:グループ名は必須
   validates :name, presence: true, length: { maximum: 50 }

--- a/app/models/invite_token.rb
+++ b/app/models/invite_token.rb
@@ -1,3 +1,14 @@
 class InviteToken < ApplicationRecord
   belongs_to :family_group
+
+  before_create :generate_token_and_expiry
+
+  scope :valid, -> { where('expires_at > ?', Time.current) }
+
+  private
+
+  def generate_token_and_expiry
+    self.token ||= SecureRandom.urlsafe_base64(24)
+    self.expires_at ||= 24.hours.from_now
+  end
 end

--- a/app/views/family_groups/settings.html.erb
+++ b/app/views/family_groups/settings.html.erb
@@ -1,1 +1,19 @@
 <h1>家族設定画面（準備中です）</h1>
+
+<!-- ✅ 招待リンク表示エリア -->
+<% if flash[:invite_url].present? %>
+  <div class="alert alert-info my-4">
+    <span>📨 招待リンクを発行しました：</span>
+    <a href="<%= flash[:invite_url] %>" class="link link-primary break-all">
+      <%= flash[:invite_url] %>
+    </a>
+    <p class="text-xs mt-1">このリンクを LINE で家族に送ってください。</p>
+  </div>
+<% end %>
+
+<div class="mt-6">
+  <%= button_to "LINEで家族を招待する",
+        invite_tokens_path,
+        method: :post,
+        class: "btn btn-primary w-full" %>
+</div>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -8,8 +8,8 @@
     end
   %>
 
-  <div class="toast toast-end z-50 m-4">
-    <div class="flash alert <%= color %> shadow-lg transition-opacity duration-500">
+  <div class="fixed left-1/2 bottom-24 -translate-x-1/2 z-50 flex justify-center pointer-events-none">
+    <div class="flash alert <%= color %> shadow-lg pointer-events-auto">
       <span><%= message %></span>
     </div>
   </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -23,3 +23,8 @@ ja:
               blank: "写真を選択してください"
             content:
               blank: "メッセージを入力してください"
+  invite_tokens:
+    invalid: "招待リンクが無効か、期限が切れています"
+    accepted: "招待を受け取りました。LINEログインすると家族に参加できます"
+    family_not_exist: "家族グループがまだ作成されていません"
+    issued: "招待リンクを発行しました"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,12 +8,14 @@ Rails.application.routes.draw do
   get "sessions/callback"
   get "sessions/destroy"
   get "posts/new", to: "posts#new", as: :new_post
+  get "invite/:tokens", to: "invite_tokens#setting", as: :invite
   root "home#index"
 
   resources :albums, only: [:index, :show, :new, :create]
   resources :family_groups, only: [:new, :create, :edit, :update]
   resources :children, only: [:new, :create]
   resources :posts, only: [:new, :create, :show]
+  resources :invite_tokens, only: [:create]
 
   # 仮リンク用（あとで本実装予定）
   get 'about', to: 'home#about'

--- a/test/controllers/invite_tokens_controller_test.rb
+++ b/test/controllers/invite_tokens_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class InviteTokensControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### 概要
家族招待機能の基盤として、InviteTokenモデルの作成と招待リンク発行処理を実装しました。
家族設定ページからLINEで招待リンクを発行するのを想定しています。

#### 実装内容
- InviteToken機能追加
- InviteTokenモデルを新規作成
#### 招待リンク発行
- InviteTokensController#create を実装
- 家族設定画面からPOSTで招待トークンを発行
#### 招待リンク受取
- InviteTokensController#show を実装
- 有効なトークンのみ受付
- セッションに family_group_id を保持（現在はfamilygroupがないためエラー出ることの確認ができている）
- ログイン後に家族グループへ参加できる準備
#### 画面対応
- 家族設定画面に「LINEで家族を招待する」ボタンを追加
- 招待URLを画面上に表示（今後はリンクコピーの仕組みや、LINEで直接遅れる仕組みを実装予定）
- Dock表示との重なりを回避するレイアウトに調整
#### 補足
現時点では家族グループ作成UIは未実装のため、
InviteToken発行時にグループが存在しないアラート表示になります。