### PR TITLE
家族名の作成機能を追加

### DIFF
--- a/app/controllers/family_groups_controller.rb
+++ b/app/controllers/family_groups_controller.rb
@@ -5,8 +5,23 @@ class FamilyGroupsController < ApplicationController
     @family_group = current_user.family_group
   end
 
+  def new
+    @family_group = FamilyGroup.new
+  end
+
   def edit
     @family_group = current_user.family_group
+  end
+
+  def create
+    @family_group = FamilyGroup.new(name: params[:family_group][:name])
+    if @family_group.save
+      current_user.update!(family_group: @family_group)
+      redirect_to family_settings_path, notice: t('.success')
+    else
+      flash.now[:alert] = t('.failure')
+      render :new, status: :unprocessable_entity
+    end
   end
 
   def update

--- a/app/views/family_groups/new.html.erb
+++ b/app/views/family_groups/new.html.erb
@@ -1,0 +1,12 @@
+<h1>家族グループを作成</h1>
+
+<%= form_with model: @family_group, local: true do |f| %>
+  <div class="form-control mb-4">
+    <label class="label">
+      <span class="label-text">家族名</span>
+    </label>
+    <%= f.text_field :name, class: "input input-bordered w-full" %>
+  </div>
+
+  <%= f.submit "作成する", class: "btn btn-primary w-full" %>
+<% end %>

--- a/app/views/family_groups/settings.html.erb
+++ b/app/views/family_groups/settings.html.erb
@@ -1,19 +1,36 @@
 <h1>家族設定画面（準備中です）</h1>
 
-<!-- ✅ 招待リンク表示エリア -->
-<% if flash[:invite_url].present? %>
-  <div class="alert alert-info my-4">
-    <span>📨 招待リンクを発行しました：</span>
-    <a href="<%= flash[:invite_url] %>" class="link link-primary break-all">
-      <%= flash[:invite_url] %>
-    </a>
-    <p class="text-xs mt-1">このリンクを LINE で家族に送ってください。</p>
-  </div>
-<% end %>
+<% if current_user.family_group.present? %>
 
-<div class="mt-6">
-  <%= button_to "LINEで家族を招待する",
-        invite_tokens_path,
-        method: :post,
-        class: "btn btn-primary w-full" %>
-</div>
+  <p>家族名: <%= current_user.family_group.name %></p>
+
+  <!-- ✅ 招待ボタン -->
+  <div class="mt-6">
+    <%= button_to "LINEで家族を招待する",
+          invite_tokens_path,
+          method: :post,
+          class: "btn btn-primary w-full" %>
+  </div>
+
+  <!-- ✅ 招待リンク表示 -->
+  <% if flash[:invite_url].present? %>
+    <div class="alert alert-info my-4">
+      <span>📨 招待リンクを発行しました：</span>
+      <a href="<%= flash[:invite_url] %>" class="link link-primary break-all">
+        <%= flash[:invite_url] %>
+      </a>
+      <p class="text-xs mt-1">このリンクを LINE で家族に送ってください。</p>
+    </div>
+  <% end %>
+
+<% else %>
+
+  <p>家族グループはまだ作成されていません</p>
+
+  <div class="mt-6">
+    <%= link_to "家族グループを作成する",
+          new_family_group_path,
+          class: "btn btn-primary w-full" %>
+  </div>
+
+<% end %>


### PR DESCRIPTION
### 主な変更点
#### 家族設定ページの作成
- /family_new ページを新設
- 状態によって表示内容を分岐
- 家族が存在する場合
- 家族名を表示
- 招待リンク発行ボタン表示
- 家族が存在しない場合
- 「家族グループが未作成」の表示
- 新規作成ページへの導線を表示