### PR TITLE
お子さま登録機能を実装

### DIFF
--- a/app/controllers/children_controller.rb
+++ b/app/controllers/children_controller.rb
@@ -1,5 +1,35 @@
 class ChildrenController < ApplicationController
+  before_action :require_login
   def new; end
 
-  def create; end
+  def create
+    return redirect_no_family unless current_user.family_group
+
+    child = build_child
+
+    child.save ? redirect_success : redirect_failure(child)
+  end
+
+  private
+
+  def build_child
+    current_user.family_group.children.new(child_params)
+  end
+
+  def redirect_no_family
+    redirect_to family_settings_path, alert: t('children.no_family')
+  end
+
+  def redirect_success
+    redirect_to family_settings_path, notice: t('children.created')
+  end
+
+  def redirect_failure(child)
+    flash[:errors] = child.errors.full_messages
+    redirect_to family_settings_path
+  end
+
+  def child_params
+    params.require(:child).permit(:name, :birth_date)
+  end
 end

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -1,3 +1,5 @@
 class Child < ApplicationRecord
   belongs_to :family_group
+
+  validates :name, presence: true
 end

--- a/app/views/family_groups/settings.html.erb
+++ b/app/views/family_groups/settings.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-xl mx-auto px-4 py-10">
+<div class="max-w-xl mx-auto px-4 py-10 pb-24">
 
   <!-- タイトル -->
   <h1 class="text-2xl font-semibold text-base-content mb-6">
@@ -37,6 +37,53 @@
       <% end %>
     </div>
 
+    <!-- ✅ お子さま一覧 -->
+    <div class="space-y-4 bg-base-100 rounded-box shadow p-4 mb-6">
+      <h2 class="font-semibold text-base">お子さま一覧</h2>
+
+      <% children = current_user.family_group.children %>
+
+      <% if children.any? %>
+        <ul class="menu bg-base-200 rounded-box">
+          <% children.each do |child| %>
+            <li class="px-2">
+              <div class="flex flex-col">
+                <span class="font-semibold"><%= child.name %></span>
+                <% if child.birth_date.present? %>
+                  <span class="text-sm opacity-60">
+                    <%= child.birth_date.strftime("%Y年%m月%d日") %>
+                  </span>
+                <% end %>
+              </div>
+            </li>
+          <% end %>
+        </ul>
+      <% else %>
+        <p class="text-sm opacity-60">まだ登録されていません。</p>
+      <% end %>
+    </div>
+
+    <!-- ✅ お子さま登録フォーム -->
+    <div class="space-y-4 bg-base-100 rounded-box shadow p-4 mb-6">
+      <h2 class="font-semibold text-base">お子さまを登録</h2>
+
+      <%= form_with model: Child.new, url: children_path, data: { turbo: false } do |f| %>
+        <div class="mb-3">
+          <%= f.label :name, "お名前", class: "label-text font-semibold" %>
+          <%= f.text_field :name, placeholder: "例）たろう", class: "input input-bordered w-full" %>
+        </div>
+
+        <div class="mb-3">
+          <%= f.label :birth_date, "お誕生日", class: "label-text font-semibold" %>
+          <%= f.date_field :birth_date, class: "input input-bordered w-full" %>
+        </div>
+
+        <div class="mt-4">
+          <%= f.submit "登録する", class: "btn btn-primary w-full" %>
+        </div>
+      <% end %>
+    </div>
+
     <!-- ✅ 招待ボタン -->
     <div class="mt-6">
       <%= button_to "LINEで家族を招待する",
@@ -45,23 +92,6 @@
             data: { turbo: false },
             class: "btn btn-primary w-full" %>
     </div>
-
-    <!-- ✅ 招待リンク表示 -->
-    <% if flash[:invite_url].present? %>
-      <div class="alert alert-info my-4 break-all">
-        <div>
-          <span class="font-semibold">📨 招待リンクを発行しました</span>
-          <a
-            href="<%= flash[:invite_url] %>"
-            class="block link link-primary mt-1">
-            <%= flash[:invite_url] %>
-          </a>
-          <p class="text-xs mt-1">
-            このリンクを LINE で家族に送ってください。
-          </p>
-        </div>
-      </div>
-    <% end %>
 
   <% else %>
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -28,3 +28,6 @@ ja:
     accepted: "招待を受け取りました。LINEログインすると家族に参加できます"
     family_not_exist: "家族グループがまだ作成されていません"
     issued: "招待リンクを発行しました"
+  children:
+    no_family: "家族がありません"
+    created: "お子さまを登録しました"

--- a/test/controllers/children_controller_test.rb
+++ b/test/controllers/children_controller_test.rb
@@ -1,13 +1,28 @@
 require 'test_helper'
 
 class ChildrenControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    @family_group = family_groups(:one)
+
+    log_in_as(@user)
+  end
+
   test 'should get new' do
-    get children_new_url
+    get new_child_url
     assert_response :success
   end
 
-  test 'should get create' do
-    get children_create_url
-    assert_response :success
+  test 'should create child' do
+    assert_difference('Child.count', 1) do
+      post children_url, params: {
+        child: {
+          name: 'テスト太郎',
+          birth_date: '2020-01-01'
+        }
+      }
+    end
+
+    assert_redirected_to family_settings_url
   end
 end


### PR DESCRIPTION
## 概要
家族設定画面に「お子さま登録機能」を追加しました。

## 変更内容
- 家族に紐づく子ども登録処理の実装
- 家族設定画面に以下を追加
  - お子さま一覧表示
  - お子さま登録フォーム
- スマホ画面でフッターに被らないよう余白調整

## 確認方法
1. 家族設定画面へアクセス
2. 「お子さまを登録」フォームから登録
3. 一覧に反映されることを確認

## 補足
今後、編集・削除・年齢表示などの拡張を予定