### PR TITLE
アルバム一覧画面（仮表示）の実装

### DIFF
--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -1,7 +1,9 @@
 class AlbumsController < ApplicationController
   before_action :require_login
 
-  def index; end
+  def index
+    @photos = Photo.all
+  end
 
   def require_login
     redirect_to root_path, alert: t('flash.login.required') if session[:user_id].blank?

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -5,6 +5,7 @@ class Post < ApplicationRecord
 
   # 写真添付機能
   has_one_attached :image
+  has_many :photos, dependent: :destroy
 
   validates :image, presence: true
   validates :content, presence: true, length: { maximum: 500 }

--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -1,7 +1,15 @@
-<h1>アルバム一覧</h1>
-
-<% if current_user %>
-  <p><%= current_user.name %> さんのアルバム一覧です。</p>
-<% end %>
-
-<p>まだアルバムがありません。</p>
+<div class="mt-8 px-4">
+  <% if @photos.any? %>
+    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+      <% @photos.each do |photo| %>
+        <%= render "photocard/card", photo: photo %>
+      <% end %>
+    </div>
+  <% else %>
+    <div class="text-center py-16">
+      <h2 class="text-2xl font-bold text-gray-700 mb-4">まだアルバムがありません</h2>
+      <p class="text-gray-500 mb-6">お子さまの思い出を投稿して、アルバムを作りましょう！</p>
+      <%= link_to "思い出を投稿する", new_post_path, class: "btn btn-primary" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/photocard/_card.html.erb
+++ b/app/views/photocard/_card.html.erb
@@ -1,0 +1,9 @@
+<div class="card w-full bg-base-100 shadow-xl image-full group">
+  <figure>
+    <img src="<%= photo.image_url %>" alt="<%= photo.post.title %>" class="object-cover w-full h-48" />
+  </figure>
+  <div class="card-body opacity-0 group-hover:opacity-100 transition duration-300">
+    <h2 class="card-title text-white"><%= photo.post.title %></h2>
+    <p class="text-white"><%= photo.created_at.strftime('%Y/%m/%d') %></p>
+  </div>
+</div>


### PR DESCRIPTION
### 主な変更点
- albums#index に @photos 一覧表示処理を追加
- DaisyUIベースの写真カード（photocard/_card.html.erb）を作成
- 投稿がないときの優しいガイド文表示
- モデルから photo.post.title を参照しタイトル表示
- Tailwind + DaisyUI によるレスポンシブ対応