### PR TITLE
アルバム一覧を年別表示に対応し、FamilyGroup未作成時のガードを追加

### DIFF
--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -2,7 +2,20 @@ class AlbumsController < ApplicationController
   before_action :require_login
 
   def index
-    @photos = Photo.all
+    family = current_user.family_group
+
+    # ガード（超重要）
+    unless family
+      @photos_by_year = {}
+      return
+    end
+
+    photos = family.posts
+                   .includes(:photos)
+                   .flat_map(&:photos)
+
+    @photos_by_year = photos.group_by { |photo| photo.created_at.year }
+                            .sort.reverse.to_h
   end
 
   def require_login

--- a/app/models/family_group.rb
+++ b/app/models/family_group.rb
@@ -2,8 +2,8 @@ class FamilyGroup < ApplicationRecord
   # 関連付け
   has_many :users, dependent: :nullify # 家族削除 → ユーザーは削除しない
   has_many :children, dependent: :destroy
-  has_one :album, dependent: :destroy
   has_many :invite_tokens, dependent: :destroy
+  has_many :posts, through: :users
 
   after_create :create_default_album
 

--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -1,15 +1,23 @@
 <div class="max-w-xl mx-auto px-4 py-10 pb-24">
-  <% if @photos.any? %>
-    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
-      <% @photos.each do |photo| %>
+  <% if @photos_by_year.present? %>
+
+  <% @photos_by_year.each do |year, photos| %>
+    <h2 class="text-xl font-bold text-base-content mt-8 mb-4">
+      <%= year %>年
+    </h2>
+
+    <div class="grid grid-cols-2 sm:grid-cols-3 gap-4">
+      <% photos.each do |photo| %>
         <%= render "photocard/card", photo: photo %>
       <% end %>
     </div>
+  <% end %>
+
   <% else %>
     <div class="text-center py-16">
-      <h2 class="text-2xl font-bold text-gray-700 mb-4">まだアルバムがありません</h2>
-      <p class="text-gray-500 mb-6">お子さまの思い出を投稿して、アルバムを作りましょう！</p>
-      <%= link_to "思い出を投稿する", new_post_path, class: "btn btn-primary" %>
+      <h2 class="text-2xl font-bold text-base-content mb-4">まだアルバムがありません</h2>
+      <p class="text-base-content/70 mb-6">お子さまの思い出を投稿して、アルバムを作りましょう！</p>
+      <%= link_to "思い出を投稿する", new_post_path, class: "btn btn-accent" %>
     </div>
   <% end %>
 </div>

--- a/app/views/family_groups/new.html.erb
+++ b/app/views/family_groups/new.html.erb
@@ -1,22 +1,22 @@
 <div class="max-w-md mx-auto mt-12 bg-base-100 rounded-box shadow p-6">
 
   <h1 class="text-xl font-bold text-center mb-2">
-    家族アルバムをつくりましょう
+    グループをつくりましょう
   </h1>
 
   <p class="text-center text-sm text-base-content/70 mb-6">
-    思い出を投稿するには、最初に家族グループを作成します
+    アルバムを紡ぐグループを作成します。
   </p>
 
   <%= form_with model: @family_group, local: true do |f| %>
     <div class="form-control mb-4">
-      <%= f.label :name, "家族の名前", class: "label" %>
+      <%= f.label :name, "グループの名前", class: "label" %>
       <%= f.text_field :name,
-            placeholder: "例）Dの一族",
+            placeholder: "例）Dの一族, 磯野家",
             class: "input input-bordered w-full" %>
     </div>
 
-    <%= f.submit "家族アルバムを作成する",
+    <%= f.submit "グループを作成する",
           class: "btn btn-accent hover:brightness-110 active:scale-95 transition duration-150 w-full mt-2" %>
   <% end %>
 

--- a/app/views/family_groups/settings.html.erb
+++ b/app/views/family_groups/settings.html.erb
@@ -2,11 +2,11 @@
 
   <!-- タイトル -->
   <h1 class="text-2xl font-semibold text-base-content mb-6">
-    家族設定
+    設定
   </h1>
 
   <p class="mb-6 text-base-content/70">
-    家族のメンバーを確認したり、招待リンクを発行します。
+    グループのメンバーを確認したり、招待リンクを発行します。
   </p>
 
   <% if current_user.family_group.present? %>
@@ -97,9 +97,9 @@
 
     <!-- ✅ 家族が未作成の場合 -->
     <div class="space-y-4 bg-base-100 rounded-box shadow p-4">
-      <p>まだ家族グループが作成されていません。</p>
+      <p>まだ思い出を紡ぐためのグループが作成されていません。</p>
 
-      <%= link_to "家族グループを作成する",
+      <%= link_to "グループを作成する",
             new_family_group_path,
             class: "btn btn-accent hover:brightness-110 active:scale-95 transition duration-150 w-full mt-2" %>
     </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -21,7 +21,7 @@
 
     <!-- ログイン・使い方リンク -->
     <div class="flex justify-center space-x-5">
-      <%= link_to "LINEでログイン", line_login_path, class: "text-blue-600 underline" %>
+      <%= link_to "LINEで新規登録", line_login_path, class: "text-blue-600 underline" %>
       <%= link_to '使い方', about_path, class: "px-6 py-2 bg-white border border-gray-300 text-gray-600 rounded-xl hover:bg-gray-50 transition" %>
     </div>
   </div>

--- a/app/views/posts/_no_family_group.html.erb
+++ b/app/views/posts/_no_family_group.html.erb
@@ -1,7 +1,7 @@
 <div class="text-center mt-10 space-y-4">
-  <h2 class="text-xl font-bold">まずはアルバムを作成しましょう</h2>
+  <h2 class="text-xl font-bold">まずはグループを作成しましょう</h2>
   <p class="text-gray-600">
-    思い出を投稿するには、家族グループが必要です。<br>
-    設定から家族グループを作成してください。<br/>
+    思い出を投稿するには、グループが必要です。<br>
+    設定からグループを作成してください。<br/>
   </p>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -18,7 +18,7 @@
       <% if current_user %>
         <li class="menu-title px-2 py-1">👤 <%= current_user.name %></li>
         <li><%= link_to "アルバム一覧", albums_path %></li>
-        <li><%= link_to "家族設定", "#" %></li>
+        <li><%= link_to "設定", family_settings_path %></li>
         <li><%= link_to "ログアウト", logout_path, data: { turbo_method: :delete }, class: "text-red-600" %></li>
       <% else %>
         <li><%= link_to "ログイン", "/auth/line", class: "text-primary" %></li>


### PR DESCRIPTION
### 概要
家族アルバム画面において、投稿された写真を年ごとにグルーピングして表示するように改善しました。
また、FamilyGroup未作成ユーザーがアクセスした場合にエラーにならないよう、ガード処理を追加しました。

#### 1. アルバム一覧を年別表示に変更
- Photo の created_at をもとに年ごとにグルーピング
- 年ごとの見出し (2025年 など) を表示するUIに変更
- 写真一覧をカード形式で表示
#### 2. データ取得ルートの整理
- FamilyGroup に has_many :posts, through: :users を追加
- Controller側で family.posts で安全に取得可能な設計に変更
#### 3. 家族グループ未作成時のガード処理
- AlbumsController にて family_group が無い場合でもエラーにならないよう、空配列を返す対応を追加
- View側では「まだアルバムがありません」のメッセージを表示する仕様に統一