### PR TITLE
アルバムのカラム不一致を修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -47,8 +47,8 @@ class PostsController < ApplicationController
     @post = current_user.posts.build(post_params.except(:images))
     # 家族グループのアルバムを取得または作成して紐づけ
     family = current_user.family_group
-    # family に album があればそれを使う。 なければ新規作成。
-    album = family.album || family.create_album!(name: family.name)
+    # family に album があればそれを使う、なければ新規作成
+    album = family.album || family.create_album!
     # 上記で取得または作成した album を post に紐づけ
     @post.album = album
   end


### PR DESCRIPTION
### 概要
本番環境でのアルバム保存時のエラー（Albumのカラム不一致）を修正

### 背景
Render本番環境で思い出投稿時に以下のエラーが発生していた。

ActiveModel::UnknownAttributeError (unknown attribute 'name' for Album.)


Albumモデルに `name` カラムが存在しないにも関わらず、
`family.create_album!(name: family.name)` としていたためエラーになっていた。

### 修正内容
albums テーブルには `name` カラムは存在しないため、
Albumは「家族グループに紐づくコンテナ」として生成する設計に統一。

### 修正前

```ruby
family = current_user.family_group

album = family.album || family.create_album!(name: family.name)
@post.album = album

### 修正後
```ruby
def build_post
  @post = current_user.posts.build(post_params.except(:images))

  family = current_user.family_group
  album = family.album || family.create_album!
  @post.album = album
end
```

### 補足
Albumは family_group と 1対1 で紐づく受け皿として扱い、
Post保存時に必ず既存のアルバムを使用、または自動生成される設計を目指す


