### PR TITLE
031 feature/group posts by photo date

### DIFF
--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -4,20 +4,53 @@ class AlbumsController < ApplicationController
   def index
     family = current_user.family_group
 
-    # ガード（超重要）
-    unless family
-      @photos_by_year = {}
-      return
-    end
-
-    photos = family.posts
-                   .includes(:photos)
-                   .flat_map(&:photos)
-
-    @photos_by_year = photos.group_by { |photo| photo.created_at.year }
-                            .sort.reverse.to_h
+    @posts_by_year =
+      if family
+        build_grouped_posts(family)
+      else
+        {}
+      end
   end
 
+  private
+
+  # ===== グルーピング処理の本体 =====
+  def build_grouped_posts(family)
+    posts = load_posts(family)
+
+    with_date, without_date = split_posts(posts)
+
+    grouped = group_by_year(with_date)
+
+    append_without_date(grouped, without_date)
+  end
+
+  # 投稿を写真付きでロード（N+1回避）
+  def load_posts(family)
+    family.posts.includes(:photos)
+  end
+
+  # 撮影日あり・なしで分割
+  def split_posts(posts)
+    with_date    = posts.select { |p| p.photo_date.present? }
+    without_date = posts.reject { |p| p.photo_date.present? }
+    [with_date, without_date]
+  end
+
+  # 年別にグループ化して降順ソート
+  def group_by_year(posts)
+    posts.group_by { |p| p.photo_date.year }
+         .sort_by { |year, _| -year }
+         .to_h
+  end
+
+  # 撮影日未設定グループを最後尾に追加
+  def append_without_date(grouped, without_date)
+    grouped['撮影日未設定'] = without_date if without_date.any?
+    grouped
+  end
+
+  # ログイン必須
   def require_login
     redirect_to root_path, alert: t('flash.login.required') if session[:user_id].blank?
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -7,6 +7,8 @@ class PostsController < ApplicationController
   end
 
   def create
+    Rails.logger.debug { "POST PARAMS: #{post_params}" }
+
     assign_family_group_flag
     build_and_save_post
   end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,17 +1,41 @@
-// Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
+// Configure your import map in config/importmap.rb.
+// Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
 import "controllers"
 
+// Turbo読み込み完了時に処理
 document.addEventListener("turbo:load", () => {
-    const flashes = document.querySelectorAll(".flash");
-  
-    flashes.forEach((flash) => {
-      setTimeout(() => {
-        flash.classList.add("opacity-0"); // フェードアウト
-      }, 3000);
-  
-      setTimeout(() => {
-        flash.remove(); // DOMから削除
-      }, 3500);
+
+  // ---------------------------
+  // ✅ フラッシュメッセージ自動消去
+  // ---------------------------
+  const flashes = document.querySelectorAll(".flash");
+
+  flashes.forEach((flash) => {
+    setTimeout(() => {
+      flash.classList.add("opacity-0"); // フェードアウト
+    }, 3000);
+
+    setTimeout(() => {
+      flash.remove(); // DOMから削除
+    }, 3500);
+  });
+
+
+  // ---------------------------
+  // ✅ Swiper 初期化（複数対応）
+  // ---------------------------
+  document.querySelectorAll(".swiper").forEach((swiperElement) => {
+    new Swiper(swiperElement, {
+      loop: true,               // ループあり
+      pagination: {
+        el: ".swiper-pagination",
+        clickable: true,
+      },
+      slidesPerView: 1,         // 1枚ずつ表示
+      spaceBetween: 10,         // スライド間の余白
+      centeredSlides: true,     // 中央寄せ
     });
+  });
+
 });

--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -1,17 +1,27 @@
 <div class="max-w-xl mx-auto px-4 py-10 pb-24">
-  <% if @photos_by_year.present? %>
+  <% if @posts_by_year.present? %>
 
-  <% @photos_by_year.each do |year, photos| %>
-    <h2 class="text-xl font-bold text-base-content mt-8 mb-4">
-      <%= year %>年
-    </h2>
+  <% @posts_by_year.each do |year, posts| %>
 
+    <%# ---- 年の表示（未設定だけ特別デザイン） ---- %>
+    <% if year == "撮影日未設定" %>
+      <h2 class="text-xl font-bold text-base-content mt-8 mb-4">
+        <span class="inline-block px-2 py-1 rounded-md bg-base-200 text-base-content/70">
+          撮影日未設定
+        </span>
+      </h2>
+    <% else %>
+      <h2 class="text-xl font-bold text-base-content mt-8 mb-4"><%= year %>年</h2>
+    <% end %>
+
+  <%# ---- 投稿のカード表示 ---- %>
     <div class="grid grid-cols-2 sm:grid-cols-3 gap-4">
-      <% photos.each do |photo| %>
-        <%= render "photocard/card", photo: photo %>
+      <% posts.each do |post| %>
+        <%= render "postcard/card", post: post %>
       <% end %>
     </div>
-  <% end %>
+
+    <% end %>
 
   <% else %>
     <div class="text-center py-16">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,24 +1,42 @@
 <!DOCTYPE html>
+<%# daisyUIのカスタムテーマ「caramellatte」を適用 %>
 <html data-theme="caramellatte">
+  <%# ページの設定エリア %>
   <head>
     <%= favicon_link_tag 'favicon.png' %>
-    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined"
-      rel="stylesheet">
+
+    <%# Google FontsのMaterial Symbols Outlinedを読み込み %>
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
+
+    <%# SwiperのCSSを読み込み 画像スライダー（Swiper）の見た目を定義するCSS %>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css" />
 
     <title><%= content_for(:title) || "Tsumugi" %></title>
+
+    <%# ビューポートの設定とモバイル対応 %>
     <meta name="viewport" content="width=device-width,initial-scale=1">
+
+    <%# iOSでWebアプリをホーム画面に追加した際のフルスクリーン表示を有効化 %>
     <meta name="apple-mobile-web-app-capable" content="yes">
+
+    <%# フォーム送信時の「CSRF対策トークン」を <meta> に埋め込むヘルパー %>
+    <%# form_with などがここからトークンを読んで、安全にPOSTできるようになる %>
     <%= csrf_meta_tags %>
+
+    <%# コンテンツセキュリティポリシー（CSP）を設定するヘルパー %>
     <%= csp_meta_tag %>
 
     <%= yield :head %>
 
+    <%# PWA（スマホのホーム画面に追加するウェブアプリ）の設定ファイルを指定 %>
     <link rel="manifest" href="/manifest.json">
 
+    <%# application.css と JavaScript のインクルード %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
 
+  <%# bodyタグにdaisyUIのユーティリティクラスを適用 %>
   <body class="bg-base-100 text-base-content min-h-screen flex flex-col">
     <%= render "shared/header" %>
     <%= render "shared/flash" %>
@@ -28,5 +46,8 @@
     </main>
 
     <%= render "shared/bottom_nav" if current_user %>
+
+    <%# SwiperのJavaScriptを読み込み 画像スライダー（Swiper）の動作を定義するJS %>
+    <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>
   </body>
 </html>

--- a/app/views/photocard/_card.html.erb
+++ b/app/views/photocard/_card.html.erb
@@ -1,7 +1,0 @@
-<div class="relative rounded-xl overflow-hidden shadow">
-
-  <% if photo.image.attached? %>
-    <%= image_tag photo.image, class: "w-full h-48 object-cover" %>
-  <% end %>
-
-</div>

--- a/app/views/postcard/_card.html.erb
+++ b/app/views/postcard/_card.html.erb
@@ -1,0 +1,23 @@
+<div class="relative rounded-xl overflow-hidden shadow">
+
+  <% if post.photos.any? %>
+
+    <div class="swiper">
+
+      <div class="swiper-wrapper">
+        <% post.photos.each do |photo| %>
+          <% if photo.image.attached? %>
+            <div class="swiper-slide">
+              <%= image_tag photo.image, class: "w-full h-48 object-cover" %>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+
+      <div class="swiper-pagination"></div>
+
+    </div>
+
+  <% end %>
+
+</div>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -12,15 +12,15 @@
     <%# ✅ 共通エラーパーツを呼び出し %>
     <%= render "shared/form_errors", object: @post %>
 
-    <%# local: true を指定して同期通信にする %>
+    <%# turbo: false を指定してTurboフォーム送信を無効化  Postが複数回送信される問題を回避 %>
     <%# multipart: true を指定してファイルアップロードを有効にする %>
-    <%= form_with model: @post, local: true, html: { multipart: true } do |f| %>
+    <%= form_with model: @post, data: { turbo: false }, html: { multipart: true } do |f| %>
 
     <%# 撮影日 %>
     <div class="mb-4">
       <%= f.label :photo_date, "撮影日", class: "label" %>
       <%= f.date_field :photo_date,
-            class: "input input-bordered w-full", 
+            class: "input input-bordered w-full",
             required: true %>
     </div>
 


### PR DESCRIPTION
## 概要
アルバム一覧画面において、投稿を「撮影日」でグループ化して表示する機能を追加しました。
撮影日が未設定の投稿は「撮影日未設定」グループとして最後にまとめています。

## 主な変更点
- AlbumsController#index のリファクタリング
- 撮影日の有無で投稿を仕分け、年ごとに降順で表示
- 「撮影日未設定」セクションの追加
- N+1 問題回避のため posts.includes(:photos) を追加
- RuboCop 警告解消のためロジックを private メソッドに分離

## 今後予定している改善
- スライダー UI の追加
- 投稿詳細画面との連携
