### PR TITLE
削除機能の改修

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,43 +1,33 @@
-// Configure your import map in config/importmap.rb.
-// Read more: https://github.com/rails/importmap-rails
+// Importmap 用の設定（Rails 7 の標準構成）
 import "@hotwired/turbo-rails"
 import "controllers"
-import "@rails/ujs"
-RadioNodeList,start()
 
-// Turbo読み込み完了時に処理
+// ✅ Turbo 読み込み完了後に実行
 document.addEventListener("turbo:load", () => {
-
   // ---------------------------
   // ✅ フラッシュメッセージ自動消去
   // ---------------------------
   const flashes = document.querySelectorAll(".flash");
-
   flashes.forEach((flash) => {
-    setTimeout(() => {
-      flash.classList.add("opacity-0"); // フェードアウト
-    }, 3000);
-
-    setTimeout(() => {
-      flash.remove(); // DOMから削除
-    }, 3500);
+    setTimeout(() => flash.classList.add("opacity-0"), 3000); // フェードアウト
+    setTimeout(() => flash.remove(), 3500);                   // DOMから削除
   });
-
 
   // ---------------------------
   // ✅ Swiper 初期化（複数対応）
   // ---------------------------
   document.querySelectorAll(".swiper").forEach((swiperElement) => {
+    const slideCount = swiperElement.querySelectorAll(".swiper-slide").length;
+
     new Swiper(swiperElement, {
-      loop: true,               // ループあり
+      loop: slideCount > 1, // スライドが2枚以上のときだけループ
       pagination: {
         el: ".swiper-pagination",
         clickable: true,
       },
-      slidesPerView: 1,         // 1枚ずつ表示
-      spaceBetween: 10,         // スライド間の余白
-      centeredSlides: true,     // 中央寄せ
+      slidesPerView: 1,
+      spaceBetween: 10,
+      centeredSlides: true,
     });
   });
-
 });

--- a/app/javascript/controllers/menu_controller.js
+++ b/app/javascript/controllers/menu_controller.js
@@ -1,6 +1,4 @@
 import { Controller } from "@hotwired/stimulus"
-import Swiper from "swiper/bundle"
-import "swiper/css/bundle"
 
 export default class extends Controller {
   static targets = []
@@ -12,17 +10,18 @@ export default class extends Controller {
   open(event) {
     const id = event.currentTarget.dataset.modalId
     const modal = document.getElementById(`modal-${id}`)
+
     if (modal) {
       modal.classList.remove("hidden")
 
-      // Swiper初期化
+      // ✅ Swiper初期化（CDNで読み込み済みのグローバルSwiperを使用）
       if (!modal.dataset.swiperInitialized) {
         const swiper = new Swiper(`#modal-${id} .swiper`, {
           loop: false,
           pagination: {
             el: `#modal-${id} .swiper-pagination`,
-            clickable: true
-          }
+            clickable: true,
+          },
         })
 
         this.swipers[id] = swiper

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
     <%# SwiperのCSSを読み込み 画像スライダー（Swiper）の見た目を定義するCSS %>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css" />
     <%# SwiperのJavaScriptを読み込み 画像スライダー（Swiper）の動作を定義するJS %>
-    <script src="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>
 
     <title><%= content_for(:title) || "Tsumugi" %></title>
 
@@ -19,7 +19,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
 
     <%# iOSでWebアプリをホーム画面に追加した際のフルスクリーン表示を有効化 %>
-    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
 
     <%# フォーム送信時の「CSRF対策トークン」を <meta> に埋め込むヘルパー %>
     <%# form_with などがここからトークンを読んで、安全にPOSTできるようになる %>
@@ -49,7 +49,5 @@
 
     <%= render "shared/bottom_nav" if current_user %>
 
-    <%# SwiperのJavaScriptを読み込み 画像スライダー（Swiper）の動作を定義するJS %>
-    <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>
   </body>
 </html>

--- a/app/views/posts/_modal.html.erb
+++ b/app/views/posts/_modal.html.erb
@@ -39,7 +39,7 @@
               <li>
                 <%= link_to '削除', post_path(post),
                             method: :delete,
-                            data: { confirm: "削除してもよろしいですか？", turbo: false },
+                            data: { turbo_method: :delete, turbo_confirm: "削除してもよろしいですか？"},
                             class: "block px-4 py-2 text-red-600 hover:bg-gray-100" %>
               </li>
             <% end %>


### PR DESCRIPTION
### 主な変更内容
- link_to に turbo_method: :delete および turbo_confirm を使用しての削除処理に変更
- Swiper 警告対策
- スライドが1枚以下の場合、Swiperで loop: false を自動設定し、コンソール警告を抑制。


