### PR TITLE
家族招待機能の改善

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -10,6 +10,16 @@ class SessionsController < ApplicationController
     redirect_to root_path, notice: t('flash.logout.success')
   end
 
+  def build_user_from_auth(auth)
+    # --- ログ出力（LINEから渡された情報を確認） ---
+    log_auth_info(auth)
+    # --- LINE UID を元にユーザーを新規作成 or 取得 ---
+    user = find_or_create_user(auth)
+    # --- 招待リンク経由でアクセスしている場合、家族グループに自動参加させる ---
+    assign_user_to_invited_group(user)
+    user
+  end
+
   # 開発環境用の簡易ログイン
   def dev_login
     user = User.find(params[:id])
@@ -26,15 +36,6 @@ class SessionsController < ApplicationController
     login_success
   rescue StandardError => e
     login_failure(e)
-  end
-
-  # --- User作成まで ---
-  def build_user_from_auth(auth)
-    log_auth_info(auth)
-    User.find_or_create_by!(line_uid: auth['uid']) do |u|
-      u.name = auth.dig('info', 'name')
-      u.email = nil
-    end
   end
 
   # --- ログインセッション管理 ---
@@ -58,5 +59,21 @@ class SessionsController < ApplicationController
     Rails.logger.info "LINE UID: #{auth['uid']}"
     Rails.logger.info "NAME: #{auth.dig('info', 'name')}"
     Rails.logger.info "IMAGE: #{auth.dig('info', 'image')}"
+  end
+
+  def find_or_create_user(auth)
+    User.find_or_create_by!(line_uid: auth['uid']) do |u|
+      u.name  = auth.dig('info', 'name')
+      u.email = nil
+    end
+  end
+
+  def assign_user_to_invited_group(user)
+    invite_group_id = session[:invite_family_group_id]
+    return unless invite_group_id.present? && user.family_group.nil?
+
+    user.update!(family_group_id: invite_group_id)
+    Rails.logger.info "ユーザー#{user.id}をグループ#{invite_group_id}に追加しました"
+    session.delete(:invite_family_group_id)
   end
 end


### PR DESCRIPTION
## 概要
LINE招待リンク経由で新規登録したユーザーを、正しく招待元のFamilyGroupに自動参加させる仕組みを実装。

### 修正内容
#### 1. セッションに招待情報を保存
InviteTokensController#show にて、招待リンクを踏んだ際に該当グループIDをセッションへ保存：
```ruby
session[:invite_family_group_id] = invite.family_group_id
```
#### 2. LINEログイン時にグループへ紐づけ
SessionsControllerの中で、ログイン処理時にセッション内のinvite_family_group_idを確認し、
新規ユーザーにグループを紐づけて保存：
```ruby
if session[:invite_family_group_id].present? && user.family_group.nil?
  user.update!(family_group_id: session[:invite_family_group_id])
  session.delete(:invite_family_group_id)
end
```
#### 3. ログ出力の追加
デバッグ用に、ユーザーがグループに追加されたことを確認するログを追加：
```ruby
Rails.logger.info "ユーザー#{user.id}をグループ#{session[:invite_family_group_id]}に追加しました"
```
#### 状況
- 現時点では端末が用意できていないため、LINEログインを含む招待フローの実機検証は未完了
- 実機での動作確認を後日実施予定
- 新しいブランチでは、別の機能開発・改善を進行予定