### PR TITLE
家族一覧の表示スタイルをお子さま一覧と統一（横並びバッジ表示に変更）

### DIFF
--- a/app/views/family_groups/settings.html.erb
+++ b/app/views/family_groups/settings.html.erb
@@ -9,77 +9,46 @@
     グループのメンバーを確認したり、招待リンクを発行します。
   </p>
 
-  <% if current_user.family_group.present? %>
+  <% family_group = current_user.family_group %>
+  <% members = family_group&.users || [] %>
+  <% children = family_group&.children || [] %>
+
+  <% if family_group.present? %>
 
     <!-- 家族名 -->
     <div class="mb-4 text-base-content font-semibold">
-      家族名：<%= current_user.family_group.name %>
+      家族名：<%= family_group.name %>
     </div>
 
-    <!-- ✅ 家族一覧 -->
-    <div class="space-y-4 bg-base-100 rounded-box shadow p-4 mb-6">
-      <h2 class="font-semibold text-base">家族一覧</h2>
-
-      <% members = current_user.family_group.users %>
-
-      <% if members.any? %>
-        <ul class="menu bg-base-200 rounded-box">
-          <% members.each do |user| %>
-            <li>
-              <span class="px-2">
-                <%= user.name.presence || "未設定ユーザー" %>
-              </span>
-            </li>
-          <% end %>
-        </ul>
-      <% else %>
-        <p class="text-sm opacity-60">まだ家族が登録されていません。</p>
-      <% end %>
-    </div>
-
-    <!-- ✅ お子さま一覧（追加ボタン付き） -->
-    <div class="space-y-4 bg-base-100 rounded-box shadow p-4 mb-6">
-      <div class="flex items-center justify-between">
-        <h2 class="font-semibold text-base">お子さま一覧</h2>
-        <%= link_to "+ 追加", new_child_path,
-              class: "btn btn-sm btn-outline btn-accent" %>
+    <!-- 家族一覧 -->
+    <% if members.any? %>
+      <div class="flex flex-wrap gap-2">
+        <% members.each do |user| %>
+          <span class="px-4 py-2 bg-base-200 text-base-content rounded-full text-sm shadow">
+            <%= user.name.presence || "未設定ユーザー" %>
+          </span>
+        <% end %>
       </div>
+    <% else %>
+      <p class="text-sm opacity-60">まだ家族が登録されていません。</p>
+    <% end %>
 
-      <% children = current_user.family_group.children %>
-
-      <% if children.any? %>
-        <div class="flex flex-wrap gap-2">
-          <% children.each do |child| %>
-            <%= link_to edit_child_path(child), class: "bg-base-200 rounded-box px-4 py-2 hover:bg-base-300 transition duration-150 block" do %>
-              <span class="font-semibold"><%= child.name %></span>
-            <% end %>
+    <!-- 子供一覧 -->
+    <% if children.any? %>
+      <div class="flex flex-wrap gap-2">
+        <% children.each do |child| %>
+          <%= link_to edit_child_path(child), class: "..." do %>
+            <span class="font-semibold"><%= child.name %></span>
           <% end %>
-        </div>
-      <% else %>
-        <p class="text-sm opacity-60">まだ登録されていません。</p>
-      <% end %>
-    </div>
-
-    <!-- ✅ 招待ボタン -->
-    <div class="mt-6">
-      <%= button_to "LINEで家族を招待する",
-            invite_tokens_path,
-            method: :post,
-            data: { turbo: false },
-            class: "btn btn-accent hover:brightness-110 active:scale-95 transition duration-150 w-full mt-2" %>
-    </div>
+        <% end %>
+      </div>
+    <% else %>
+      <p class="text-sm opacity-60">まだ登録されていません。</p>
+    <% end %>
 
   <% else %>
 
-    <!-- ✅ 家族が未作成の場合 -->
-    <div class="space-y-4 bg-base-100 rounded-box shadow p-4">
-      <p>まだ思い出を紡ぐためのグループが作成されていません。</p>
-
-      <%= link_to "グループを作成する",
-            new_family_group_path,
-            class: "btn btn-accent hover:brightness-110 active:scale-95 transition duration-150 w-full mt-2" %>
-    </div>
+    <!-- グループ未作成時 -->
+    <p>まだ思い出を紡ぐためのグループが作成されていません。</p>
 
   <% end %>
-
-</div>


### PR DESCRIPTION
## 概要
- 設定画面の「家族一覧」表示を、お子さま一覧と同じように横並びのバッジ表示に変更しました。
### 変更点
- 家族一覧 のERBコードを ul > li リスト形式から flex に変更
- Tailwind CSSクラスで見た目をバッジ風に（px-4 py-2 bg-base-200 rounded-full など）
- 表示の統一感と可読性を高めました
- ビュー内で使用していた members や children の変数を冒頭でまとめて定義することで、ロジックの見通しを改善しました