### PR TITLE
投稿編集画面のUI/UX改善

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,7 +40,8 @@
 
   <%# bodyタグにdaisyUIのユーティリティクラスを適用 %>
   <body class="bg-base-100 text-base-content min-h-screen flex flex-col">
-    <%= render "shared/header" %>
+    <%# 共通ヘッダーを抑制するコンテンツが設定されていない場合にのみ表示 %>
+    <%= render "shared/header" unless content_for(:suppress_header) == true %>
     <%= render "shared/flash" %>
 
     <main>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -3,11 +3,6 @@
     思い出を投稿
   </h1>
 
-  <p class="mb-6 text-base-content/70">
-    ここでは、写真やひとことメッセージを投稿して、
-    パートナーと一緒にアルバムを作っていきます。
-  </p>
-
   <div class="space-y-4 bg-base-100 rounded-box shadow p-4">
     <%# ✅ 共通エラーパーツを呼び出し %>
     <%= render "shared/form_errors", object: @post %>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,8 +1,27 @@
-<div class="max-w-xl mx-auto px-4 py-10 pb-24">
+<!-- 編集ページヘッダー抑制 -->
+<% content_for :suppress_header, true %>
+<!-- 編集ページカスタムヘッダー -->
+<div class="fixed top-0 left-0 w-full z-50 flex items-center justify-between bg-base-300 text-base-content px-4 py-3 border-b border-base-200">
+  <!-- キャンセル（戻る）ボタン -->
+  <div class="w-20 flex-shrink-0">
+    <%= link_to "キャンセル", "javascript:history.back()", class: "text-sm" %>
+  </div>
 
-  <h1 class="text-2xl font-bold text-base-content mb-6">
+  <!-- タイトル -->
+  <h2 class="text-base font-bold text-center flex-grow truncate">
     思い出を編集
-  </h1>
+  </h2>
+
+  <!-- 完了（保存）ボタン -->
+  <div class="w-20 text-right flex-shrink-0">
+    <button type="submit" form="edit-post-form" class="text-sm text-accent font-semibold">
+      完了
+    </button>
+  </div>
+</div>
+
+<!-- 本体 -->
+<div class="max-w-xl mx-auto px-4 py-14 pb-24">
 
   <%= render "shared/form_errors", object: @post %>
 
@@ -10,7 +29,7 @@
   <% if @post.photos.any? %>
     <div class="mb-8">
       <h2 class="text-lg font-semibold text-base-content mb-3">
-        登録されている写真
+        写真
       </h2>
 
       <div class="swiper rounded-xl overflow-hidden shadow">
@@ -29,11 +48,8 @@
     </div>
   <% end %>
 
-  <%# -------------------------------------- %>
-  <%#           編集フォーム本体             %>
-  <%# -------------------------------------- %>
-
-  <%= form_with model: @post, local: true, html: { multipart: true } do |f| %>
+  <%# --- 投稿編集フォーム --- %>
+  <%= form_with model: @post, local: true, html: { multipart: true, id: "edit-post-form" } do |f| %>
 
     <%# --- 撮影日 --- %>
     <div class="mb-6">
@@ -51,11 +67,6 @@
     <div class="mb-6">
       <%= f.label :content, "ひとことメッセージ", class: "label font-medium text-base-content" %>
       <%= f.text_area :content, rows: 4, class: "textarea textarea-bordered w-full" %>
-    </div>
-
-    <%# --- 提出ボタン --- %>
-    <div class="flex justify-end mt-8">
-      <%= f.submit "更新する", class: "btn btn-accent px-6" %>
     </div>
 
   <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,3 +1,7 @@
+<%# 共通ヘッダーを抑制するコンテンツが設定されていない場合にのみ表示 %>
+<% unless content_for?(:suppress_header) %>
+
+<!-- 共通ヘッダー部分 -->
 <header class="w-full bg-base-300 text-base-content shadow-sm px-4 h-14 flex justify-between items-center">
   <h1 class="text-xl font-bold">
     <%= link_to "Tsumugi", root_path %>
@@ -26,5 +30,6 @@
     </ul>
   </div>
   <!-- ▲▲▲ header 内に置く ▲▲▲ -->
-
 </header>
+
+<% end %>


### PR DESCRIPTION
### 主な変更点
- モーダル画面と統一感のあるカスタムヘッダーを実装（「キャンセル」「思い出を編集」「完了」）
- content_for :suppress_header を活用して共通ヘッダーを抑制
- 「キャンセル」で前の画面に戻れるよう javascript:history.back() を使用
- 編集完了ボタンで正しく送信されるよう、formの id を form_with に追加し、ボタンに form="..." を指定
- その他スタイルの微調整（余白、レスポンシブ等）