### PR TITLE
model/family_groupからafter_createを削除

### DIFF
--- a/app/models/family_group.rb
+++ b/app/models/family_group.rb
@@ -8,5 +8,4 @@ class FamilyGroup < ApplicationRecord
 
   # バリデーション:グループ名は必須
   validates :name, presence: true, length: { maximum: 50 }
-
 end


### PR DESCRIPTION
### 概要
過去の構想で使用していた after_create による自動処理を整理
アプリの仕様変更に伴い、グループ作成時の初期アルバム生成等は不要と判断
### 変更内容
- after_create を削除
- create_default_album などの不要メソッドを削除
- FamilyGroupsController#create をシンプルに保ち、current_user との関連付けのみ行うよう修正
### 背景・理由
- 当初はグループ作成と同時に初期データを生成する設計だったが、仕様の見直しにより不要となった
- コードの責務を明確に保ち、意図しない副作用を避けるため