### PR TITLE
フラッシュメッセージの修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -27,7 +27,7 @@ class PostsController < ApplicationController
 
   def destroy
     @post.destroy
-    redirect_to albums_path, notice: t('flash.posts.destroyed')
+    redirect_to albums_path, notice: t('flash.posts.deleted')
   end
 
   private
@@ -95,17 +95,11 @@ class PostsController < ApplicationController
   # ==================================================
   def handle_success
     attach_images
-    redirect_to albums_path, notice: t('.success')
+    redirect_to albums_path, notice: t('flash.posts.created')
   end
 
   def handle_failure
     Rails.logger.debug { "❌ save failed: #{@post.errors.full_messages}" }
-    render :new, status: :unprocessable_entity
-  end
-
-  def render_without_images
-    @post = Post.new(post_params.except(:images))
-    @post.errors.add(:base, '写真を1枚以上アップロードしてください')
     render :new, status: :unprocessable_entity
   end
 
@@ -120,14 +114,6 @@ class PostsController < ApplicationController
   def authorize_user!
     return if @post.user == current_user
 
-    redirect_to albums_path, alert: t('flash.authorization.denied')
-  end
-
-  def delete_selected_photos
-    return unless params[:delete_photos]
-
-    params[:delete_photos].each do |photo_id|
-      @post.photos.find(photo_id).destroy
-    end
+    redirect_to albums_path, alert: t('flash.authorization.failed')
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -16,9 +16,9 @@ ja:
         failure: "家族グループの更新に失敗しました"
 
     posts:
-      created: "投稿しました"
-      updated: "投稿を更新しました"
-      deleted: "投稿を削除しました"
+      created: "思い出を投稿しました"
+      updated: "思い出を更新しました"
+      deleted: "思い出を削除しました"
 
     authorization:
       failure: "権限がありません"


### PR DESCRIPTION
## 概要
画像の 投稿時・削除時に表示されるフラッシュメッセージを見直し、
ユーザーにとって分かりやすく、挙動と文言が一致するように修正しました。

### 修正内容
- 思い出投稿・更新・削除時のフラッシュメッセージを整理
- I18n のキーとコントローラー側の参照を統一
- ユーザー操作（投稿 / 削除）に対して適切な通知が表示されるよう改善