### PR TITLE
photo_preview JSの本番エラーを修正

### DIFF
--- a/app/javascript/photo_preview.js
+++ b/app/javascript/photo_preview.js
@@ -1,8 +1,8 @@
-document.addEventListener("DOMContentLoaded", () => {
+document.addEventListener("turbo:load", () => {
   const input = document.getElementById("photo-input");
   const preview = document.getElementById("photo-preview");
 
-  if (!input) return;
+  if (!input || !preview) return
 
   input.addEventListener("change", () => {
     preview.innerHTML = "";


### PR DESCRIPTION
## 概要
写真プレビュー用JSが、要素未存在ページでも実行されていたため、
本番環境でJSエラーが発生していました。

## 修正内容
- photo_preview.js に要素存在チェックを追加
- turbo:load イベントで初期化するよう修正
- 本番環境でのアルバム一覧クリック不具合を解消
