### PR TITLE
Remove image download option from post modal

### DIFF
--- a/app/views/posts/_modal.html.erb
+++ b/app/views/posts/_modal.html.erb
@@ -43,12 +43,6 @@
                             class: "block px-4 py-2 text-red-600 hover:bg-gray-100" %>
               </li>
             <% end %>
-            <li>
-              <%= link_to '画像を保存', '#',
-                          id: "save-image-#{post.id}",
-                          download: true,
-                          class: "block px-4 py-2 hover:bg-gray-100" %>
-            </li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
## 主な変更点
モーダル画面のミートボールメニューから画像を保存の項目を削除