### PR TITLE
投稿画面のUXの変更

### DIFF
--- a/app/javascript/controllers/photo_picker_controller.js
+++ b/app/javascript/controllers/photo_picker_controller.js
@@ -7,6 +7,11 @@ export default class extends Controller {
 
   connect() {
     console.log("photo-picker connected")
+
+    // 🔑 画面表示後に自動でファイルピッカーを開く
+    requestAnimationFrame(() => {
+      this.openPicker()
+    })
   }
 
   openPicker() {

--- a/app/views/posts/select_photos.html.erb
+++ b/app/views/posts/select_photos.html.erb
@@ -85,4 +85,4 @@
     data-action="change->photo-picker#handleFiles"
   >
 
-</div>
+</form>


### PR DESCRIPTION
## 概要
写真選択時の UX を改善し、投稿画面に遷移した時点で自動的に写真選択が始まるフローに変更

### 変更内容

#### 1. 写真選択画面に遷移した際、自動でファイルピッカーを開くように変更
- photo-picker の connect() 内で openPicker() を実行
- requestAnimationFrame を使用し、描画完了後に安全に実行することで
- モバイルブラウザ（特に iOS Safari）でも安定して動作するように対応
```js
connect() {
  requestAnimationFrame(() => {
    this.openPicker()
  })
}
```
