### PR TITLE
写真選択の枚数制限をできるように実装しました

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -44,10 +44,19 @@ class PostsController < ApplicationController
 
   #  写真を仮保存し、確認プレビューを表示する
   def confirm_photos
-    return redirect_to_no_photos if params[:images].blank?
+    images = params.dig(:post, :images)
+    return redirect_to_no_photos if images.blank?
+
+    max = 5
+
+    # サーバー側で必ず制限する（最重要）
+    limited_images = images.first(max)
+
+    # 画面表示用（何枚切り捨てたか）
+    @dropped_files_count = [images.size - max, 0].max
 
     @post = build_draft_post
-    attach_photos(@post)
+    attach_photos(@post, limited_images)
   end
 
   private
@@ -74,8 +83,8 @@ class PostsController < ApplicationController
     post
   end
 
-  def attach_photos(post)
-    params[:images].each_with_index do |img, index|
+  def attach_photos(post, images)
+    images.each_with_index do |img, index|
       post.photos.create!(
         image: img,
         position: index

--- a/app/javascript/controllers/auto_dismiss_controller.js
+++ b/app/javascript/controllers/auto_dismiss_controller.js
@@ -1,0 +1,18 @@
+
+// 時間経過後に要素をフェードアウトして削除するStimulusコントローラー
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = {
+    timeout: { type: Number, default: 3000 }
+  }
+
+  connect() {
+    setTimeout(() => {
+      this.element.classList.add("opacity-0")
+      setTimeout(() => {
+        this.element.remove()
+      }, 500)
+    }, this.timeoutValue)
+  }
+}

--- a/app/javascript/controllers/photo_picker_controller.js
+++ b/app/javascript/controllers/photo_picker_controller.js
@@ -14,11 +14,27 @@ export default class extends Controller {
   }
 
   handleFiles() {
-    const files = this.inputTarget.files
-    if (!files || files.length === 0) return
+    const maxFiles = this.maxFilesValue
+    const files = Array.from(this.inputTarget.files)
+    if (files.length === 0) return
 
-    // ✅ 写真が選ばれたら即 confirm へ
+    // 超過分をカット（最初の5枚を固定）
+    let trimmedFiles = files
+    let droppedCount = 0
+
+    if (files.length > maxFiles) {
+      trimmedFiles = files.slice(0, maxFiles)
+      droppedCount = files.length - maxFiles
+    }
+
+    const dt = new DataTransfer()
+    trimmedFiles.forEach(file => dt.items.add(file))
+    this.inputTarget.files = dt.files
+
+    this.formTarget.querySelector(
+      'input[name="dropped_files_count"]'
+    ).value = droppedCount
+
     this.formTarget.submit()
   }
-
 }

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -10,4 +10,13 @@ class Post < ApplicationRecord
 
   validates :title, presence: true, length: { maximum: 100 }
   validates :content, presence: true, length: { maximum: 500 }
+  validate :photos_count_within_limit
+
+  private
+
+  def photos_count_within_limit
+    return unless photos.size > 5
+
+    errors.add(:base, '写真は最大5枚まで投稿できます')
+  end
 end

--- a/app/views/posts/confirm_photos.html.erb
+++ b/app/views/posts/confirm_photos.html.erb
@@ -17,6 +17,22 @@
     <div class="w-6"></div>
   </header>
 
+  <!-- 写真アップロードが5枚以上だった時の警告 -->
+  <% if @dropped_files_count > 0 %>
+    <div
+      data-controller="auto-dismiss"
+      data-auto-dismiss-timeout-value="3000"
+      class="absolute top-16 left-1/2 -translate-x-1/2 z-30
+             bg-warning/80 text-warning-content
+             px-4 py-2 rounded-lg text-xs
+             shadow-md
+             transition-opacity duration-500
+             pointer-events-none"
+    >
+      <%= "#{@dropped_files_count}枚の写真はアップロードできませんでした（最大5枚まで）" %>
+    </div>
+  <% end %>
+
   <!-- ===== プレビュー ===== -->
   <div class="flex-1 flex items-start justify-center px-4 pt-6 pb-30">
     <div class="w-full max-w-md">

--- a/app/views/posts/select_photos.html.erb
+++ b/app/views/posts/select_photos.html.erb
@@ -46,7 +46,7 @@
     </h2>
 
     <p class="text-sm text-base-content/70 mb-6 text-center">
-      投稿できる写真は最大3枚までです。
+      投稿できる写真は最大5枚までです。
     </p>
 
     <button
@@ -57,23 +57,24 @@
     </button>
   </div>
 
-<!-- ===== hidden form / input ===== -->
-<form
-  action="<%= confirm_photos_posts_path %>"
-  method="post"
-  enctype="multipart/form-data"
-  data-photo-picker-target="form"
-  class="hidden"
->
-  <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
-
-  <input
-    type="file"
-    name="images[]"
-    multiple
-    accept="image/*"
-    data-photo-picker-target="input"
-    data-action="change->photo-picker#handleFiles"
+  <!-- ===== hidden form / input ===== -->
+  <form
+    action="<%= confirm_photos_posts_path %>"
+    method="post"
+    enctype="multipart/form-data"
+    data-photo-picker-target="form"
+    class="hidden"
   >
+    <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
+    <%= hidden_field_tag :dropped_files_count, 0 %>
 
-</form>
+    <input
+      type="file"
+      name="post[images][]"
+      multiple
+      accept="image/*"
+      data-photo-picker-target="input"
+      data-action="change->photo-picker#handleFiles"
+    >
+  </form>
+</main>


### PR DESCRIPTION
## 概要

思い出投稿時の写真選択フローを改善し、  
フロント側のUI制御に加え、サーバー側でも最終的な枚数制限をする機能を実装しました。

---

## 実装内容

### 1. 写真選択数の制御（最大5枚）

- 写真選択時、5枚を超えて選択された場合は  
  **最初に選択された5枚のみを有効** とし、それ以降は切り捨て
- 切り捨てられた枚数を確認画面でユーザーに通知

### 2. サーバー側での制限

- フロント側の制御に依存せず、`confirm_photos` アクション内で
  - 画像配列を最大5枚に制限
  - 超過分の枚数をサーバー側で計算
- params を直接保存せず、**制限済みの配列のみを保存**する設計に変更

### 3. 確認（プレビュー）画面での通知表示

- 超過があった場合のみ、写真の上に削除された枚数と最大5枚しか登録できないことを知らせるメッセージを表示

## 動作確認

- [x] 写真を5枚以内で選択 → 通常どおり確認画面へ遷移
- [x] 写真を6枚以上選択 → 最初の5枚のみ表示され、超過枚数が通知される
- [x] 通知は数秒後に自動で消える
- [x] DBには最大5枚までしか保存されないことを確認
