### PR TITLE
アルバム一覧・モーダル表示改善

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -11,23 +11,5 @@ document.addEventListener("turbo:load", () => {
   flashes.forEach((flash) => {
     setTimeout(() => flash.classList.add("opacity-0"), 3000); // フェードアウト
     setTimeout(() => flash.remove(), 3500);                   // DOMから削除
-  });
-
-  // ---------------------------
-  // ✅ Swiper 初期化（複数対応）
-  // ---------------------------
-  document.querySelectorAll(".swiper").forEach((swiperElement) => {
-    const slideCount = swiperElement.querySelectorAll(".swiper-slide").length;
-
-    new Swiper(swiperElement, {
-      loop: slideCount > 1, // スライドが2枚以上のときだけループ
-      pagination: {
-        el: ".swiper-pagination",
-        clickable: true,
-      },
-      slidesPerView: 1,
-      spaceBetween: 10,
-      centeredSlides: true,
-    });
-  });
-});
+  })
+})

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -2,35 +2,28 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   open(event) {
-
-    const id = event.currentTarget.dataset.modalId
+    const id = this.element.dataset.modalId || event.currentTarget.dataset.modalId
     const modal = document.getElementById(`modal-${id}`)
 
-    if (modal) {
-      modal.classList.remove("hidden")
+    if (!modal) return
 
-      // Swiperの初期化（初回のみ）
-      if (!modal.dataset.swiperInitialized) {
-        // 👇 window.Swiper を使う
-        new window.Swiper(`#modal-${id} .swiper`, {
-          loop: false,
-          pagination: {
-            el: `#modal-${id} .swiper-pagination`,
-            clickable: true,
-          },
-        })
+    // ① モーダルを表示
+    modal.classList.remove("hidden")
 
-        modal.dataset.swiperInitialized = true
-      }
-    } else {
-      console.warn(`❌ モーダル modal-${id} が見つかりません`)
+    // ② 中の swiper_controller を探す
+    const swiperElement = modal.querySelector('[data-controller="swiper"]')
+
+    if (swiperElement) {
+      const controller = this.application.getControllerForElementAndIdentifier(
+        swiperElement,
+        "swiper"
+      )
+
+      controller?.init()
     }
   }
 
-  close(event) {
-    const modal = event.currentTarget.closest("[id^=modal-]")
-    if (modal) {
-      modal.classList.add("hidden")
-    }
+  close() {
+    this.element.classList.add("hidden")
   }
 }

--- a/app/javascript/controllers/swiper_controller.js
+++ b/app/javascript/controllers/swiper_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  init() {
+    if (this.swiper) return
+
+    this.swiper = new window.Swiper(this.element, {
+      loop: false,
+      pagination: {
+        el: this.element.querySelector(".swiper-pagination"),
+        clickable: true,
+      },
+      slidesPerView: 1,
+      spaceBetween: 10,
+      centeredSlides: true,
+    })
+  }
+}

--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -32,21 +32,6 @@
 
   <% else %>
     <%# 投稿なし %>
-    <div class="text-center py-20 space-y-6">
-      <div class="w-40 mx-auto animate-bounce">
-        <%= image_tag "no_album.png", alt: "アルバムが空の状態" %>
-      </div>
-
-      <h2 class="text-lg font-semibold text-base-content/80">
-        まだ思い出が投稿されていません
-      </h2>
-      <p class="text-sm text-base-content/60">
-        思い出を投稿して、アルバムを作りましょう。
-      </p>
-
-      <%= link_to "思い出を投稿する", new_post_path,
-            class: "btn btn-accent mt-4" %>
-    </div>
+    <%= render "albums/empty" %>
   <% end %>
 </div>
-

--- a/app/views/posts/_modal.html.erb
+++ b/app/views/posts/_modal.html.erb
@@ -1,5 +1,9 @@
 <!-- モーダル本体 -->
-<div id="modal-<%= post.id %>" class="fixed inset-0 z-50 bg-black bg-opacity-80 flex items-center justify-center hidden" data-controller="modal">
+<div
+  id="modal-<%= post.id %>"
+  class="fixed inset-0 z-50 bg-black bg-opacity-80 flex items-center justify-center hidden" data-controller="modal"
+  >
+  
   <div class="relative bg-base-100 w-full max-w-md h-full overflow-y-auto text-base-content pt-14 pb-24 rounded-lg">
 
     <!-- ヘッダー -->
@@ -48,7 +52,7 @@
       </div>
 
     <!-- 写真スライダー -->
-      <div class="swiper my-2">
+      <div class="swiper my-2" data-controller="swiper">
         <div class="swiper-wrapper">
           <% post.photos.each do |photo| %>
             <% if photo.image.attached? %>
@@ -58,6 +62,7 @@
             <% end %>
           <% end %>
         </div>
+
         <div class="swiper-pagination mt-2"></div>
       </div>
 

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -32,7 +32,7 @@
         写真
       </h2>
 
-      <div class="swiper rounded-xl overflow-hidden shadow">
+      <div class="swiper rounded-xl overflow-hidden shadow" data-controller="swiper" data-swiper-autoinit-value="true">
         <div class="swiper-wrapper">
           <% @post.photos.each do |photo| %>
             <% if photo.image.attached? %>
@@ -71,12 +71,3 @@
 
   <% end %>
 </div>
-
-<script>
-  document.addEventListener("turbo:load", () => {
-    new Swiper(".swiper", {
-      loop: true,
-      pagination: { el: ".swiper-pagination" },
-    });
-  });
-</script>


### PR DESCRIPTION
## 背景・課題
application.js にて .swiper 要素を一律初期化しており、
アルバム一覧ページ表示時にも不要な Swiper 処理が実行されていて、
ページごとの責務が曖昧になっていたため、設計の見直しが必要だった

### 実施内容
#### 1. Swiper 初期化処理を application.js から削除
- 全ページ共通で Swiper を初期化する構成を廃止
- ページ遷移・更新時に不要な処理が走らないように修正
### 2. modal / swiper の責務を Stimulus Controller で分離
- modal_controller
- モーダルの表示・非表示のみを担当
- swiper_controller
- Swiper の初期化ロジックのみを担当
#### 3. モーダル表示後に Swiper を初期化する構成へ変更
- hidden 状態での初期化を避けるため、
- モーダルを表示した後に swiper_controller#init を実行
- 表示サイズが確定した状態で初期化されるため、Swiper が正常に動作
#### 4. カードクリック時の Stimulus スコープを整理
- アルバム一覧のカード要素に data-controller="modal" を付与
- click->modal#open が正しく発火するよう修正