### PR TITLE
モーダル・プレビュー画像表示統一対応

### DIFF
--- a/app/views/posts/_modal.html.erb
+++ b/app/views/posts/_modal.html.erb
@@ -56,8 +56,10 @@
         <div class="swiper-wrapper">
           <% post.photos.each do |photo| %>
             <% if photo.image.attached? %>
-              <div class="swiper-slide">
-                <%= image_tag photo.image, class: "w-full object-cover" %>
+              <div class="swiper-slide flex justify-center items-center">
+                <div class="aspect-square w-full max-w-md bg-base-200 rounded-xl overflow-hidden">
+                  <%= image_tag photo.image, class: "w-full h-full object-cover" %>
+                </div>
               </div>
             <% end %>
           <% end %>


### PR DESCRIPTION
## 概要
思い出詳細モーダルで表示される写真のサイズ・比率が写真ごとに異なっていたため、
共通のレイアウト構造を持たせて表示サイズを統一しました。

### 変更内容
- 画像の表示比率を aspect-square に統一
- 画像そのものではなく「ラッパー（枠）」でサイズ管理
- object-cover によりトリミングを統一
- Swiper 側のサイズブレを防止

### 補足
今の比率
```txt
aspect-square (1:1)
```
もし比率を変えたいときは以下のように修正
```txt
aspect-[4/5]（縦長）
```