### PR TITLE
ヘッダー構成とUIのサイズ感を整理

### DIFF
--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -1,3 +1,12 @@
+
+<%# デフォルトヘッダー、デフォルト背景を制御%>
+<% content_for :suppress_header, true %>
+
+<div class="relative min-h-screen">
+
+<!-- ===== ヘッダー ===== -->
+  <%= render "shared/simple_header", title: "アルバム一覧" %>
+
 <div class="max-w-xl mx-auto px-4 py-10 pb-24">
   <% if @posts_by_year.present? %>
 

--- a/app/views/family_groups/settings.html.erb
+++ b/app/views/family_groups/settings.html.erb
@@ -1,13 +1,11 @@
+<%# デフォルトヘッダー、デフォルト背景を制御%>
+<% content_for :suppress_header, true %>
+
+  <!-- ===== ヘッダー ===== -->
+  <%= render "shared/simple_header", title: "家族設定" %>
+
+<!-- ===== メインコンテンツ ===== -->
 <div class="max-w-xl mx-auto px-4 py-10 pb-24">
-
-  <!-- タイトル -->
-  <h1 class="text-2xl font-semibold text-base-content mb-6">
-    設定
-  </h1>
-
-  <p class="mb-6 text-base-content/70">
-    グループメンバーの確認、追加ができます。
-  </p>
 
   <% if current_user.family_group.present? %>
 

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -1,6 +1,10 @@
-<h1 class="text-sm text-base-content/60 mb-2">
-  マイページ
-</h1>
+<%# デフォルトヘッダー、デフォルト背景を制御%>
+<% content_for :suppress_header, true %>
+
+<div class="relative min-h-screen">
+
+  <!-- ===== ヘッダー ===== -->
+  <%= render "shared/simple_header", title: "マイページ" %>
 
 <div class="bg-base-100 rounded-2xl p-5 shadow-sm border border-base-200 mb-6">
 

--- a/app/views/posts/select_photos.html.erb
+++ b/app/views/posts/select_photos.html.erb
@@ -5,13 +5,7 @@
 <div class="relative min-h-screen">
 
   <!-- ===== ヘッダー ===== -->
-  <header class="w-full bg-base-300 text-base-content shadow-sm px-4 h-14 flex justify-between items-center">
-
-    <!-- タイトル -->
-    <h1 class="text-base font-semibold">
-      新規投稿
-    </h1>
-  </header>
+  <%= render "shared/simple_header", title: "新規投稿" %>
 
   <!-- ===== メイン ===== -->
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,69 +1,31 @@
 <%# 共通ヘッダーを抑制するコンテンツが設定されていない場合にのみ表示 %>
 <% unless content_for?(:suppress_header) %>
 
-<!-- 共通ヘッダー部分 -->
-<header class="w-full bg-base-300 text-base-content shadow-sm px-4 h-14 flex justify-between items-center">
-  <h1 class="text-xl font-bold">
-    <%= link_to "Tsumugi", root_path %>
-  </h1>
+<header
+  class="w-full bg-base-300 text-base-content shadow-sm px-4 h-14
+         flex items-center relative"
+>
 
-  <div class="dropdown dropdown-end">
-    <label tabindex="0" class="btn btn-ghost btn-circle">
-      <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none"
-        viewBox="0 0 24 24" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-          d="M4 6h16M4 12h16M4 18h16"/>
-      </svg>
-    </label>
-
-    <ul tabindex="0"
-    class="dropdown-content menu bg-base-100 rounded-box w-52 p-2 shadow mt-3">
-
-      <% if current_user %>
-        <li class="menu-title">
-          <span>👤 <%= current_user.name %></span>
-        </li>
-
-        <li><%= link_to "アルバム一覧", albums_path %></li>
-        <li><%= link_to "設定", family_settings_path %></li>
-
-        <li class="menu-title mt-2">
-          <span>このアプリについて</span>
-        </li>
-        <li><%= link_to "Tumugiについて", about_path %></li>
-        <li><%= link_to "初めての方へ", how_to_use_path %></li>
-        <li><%= link_to "利用規約", terms_path %></li>
-        <li><%= link_to "プライバシーポリシー", privacy_path %></li>
-
-        <li class="menu-title mt-2">
-          <span>アカウント</span>
-        </li>
-        <li>
-          <%= link_to "ログアウト",
-                      logout_path,
-                      data: { turbo_method: :delete },
-                      class: "text-red-600" %>
-        </li>
-
-      <% else %>
-        <li>
-          <%= link_to "ログイン",
-                      "/auth/line",
-                      class: "text-primary",
-                      data: { turbo: false } %>
-        </li>
-
-        <li class="menu-title mt-2">
-          <span>このアプリについて</span>
-        </li>
-        <li><%= link_to "Tumugiについて", about_path %></li>
-        <li><%= link_to "初めての方へ", how_to_use_path %></li>
-        <li><%= link_to "利用規約", terms_path %></li>
-        <li><%= link_to "プライバシーポリシー", privacy_path %></li>
-      <% end %>
-
-    </ul>
+  <!-- 左エリア -->
+  <div class="flex-1">
+    <% unless content_for?(:center_title) %>
+      <h1 class="text-xl font-bold">
+        <%= content_for?(:page_title) ? yield(:page_title) : "Tsumugi" %>
+      </h1>
+    <% end %>
   </div>
-</header>
 
+  <!-- 中央タイトル -->
+  <% if content_for?(:center_title) %>
+    <h1 class="absolute left-1/2 -translate-x-1/2 text-base font-semibold">
+      <%= yield(:center_title) %>
+    </h1>
+  <% end %>
+
+  <!-- 右エリア（ミートボール） -->
+  <div class="flex-1 flex justify-end">
+    <%= render "shared/meatball_menu" %>
+  </div>
+
+</header>
 <% end %>

--- a/app/views/shared/_meatball_menu.html.erb
+++ b/app/views/shared/_meatball_menu.html.erb
@@ -1,0 +1,60 @@
+
+<div class="dropdown dropdown-end">
+  <label tabindex="0" class="btn btn-ghost btn-circle">
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none"
+      viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+        d="M4 6h16M4 12h16M4 18h16"/>
+    </svg>
+  </label>
+  
+  <ul tabindex="0"
+      class="dropdown-content menu bg-base-100 rounded-box w-52 p-2 shadow mt-3">
+      
+        <% if current_user %>
+          <li class="menu-title">
+            <span>👤 <%= current_user.name %></span>
+        </li>
+
+        <li><%= link_to "アルバム一覧", albums_path %></li>
+        <li><%= link_to "思い出投稿", select_photos_posts_path %></li>
+        <li><%= link_to "グループ設定", family_settings_path %></li>
+        <li><%= link_to "マイページ", mypage_path %></li>
+
+        <li class="menu-title mt-2">
+          <span>このアプリについて</span>
+        </li>
+        <li><%= link_to "Tumugiについて", about_path %></li>
+        <li><%= link_to "初めての方へ", how_to_use_path %></li>
+        <li><%= link_to "利用規約", terms_path %></li>
+        <li><%= link_to "プライバシーポリシー", privacy_path %></li>
+
+        <li class="menu-title mt-2">
+          <span>アカウント</span>
+        </li>
+        <li>
+          <%= link_to "ログアウト",
+                      logout_path,
+                      data: { turbo_method: :delete },
+                      class: "text-red-600" %>
+        </li>
+
+        <% else %>
+        
+        <li>
+          <%= link_to "ログイン",
+                      "/auth/line",
+                      class: "text-primary",
+                      data: { turbo: false } %>
+        </li>
+
+        <li class="menu-title mt-2">
+          <span>このアプリについて</span>
+        </li>
+        <li><%= link_to "Tumugiについて", about_path %></li>
+        <li><%= link_to "初めての方へ", how_to_use_path %></li>
+        <li><%= link_to "利用規約", terms_path %></li>
+        <li><%= link_to "プライバシーポリシー", privacy_path %></li>
+      <% end %>
+  </ul>
+</div>

--- a/app/views/shared/_simple_header.html.erb
+++ b/app/views/shared/_simple_header.html.erb
@@ -1,0 +1,10 @@
+
+<header class="w-full bg-base-300 shadow-sm px-4 h-14 flex items-center">
+  <h1 class="text-base font-semibold">
+    <%= title %>
+  </h1>
+
+  <div class="ml-auto">
+    <%= render "shared/meatball_menu" %>
+  </div>
+</header>


### PR DESCRIPTION
## 概要
グループ設定画面を中心に、ヘッダー構成とUIのサイズ感を整理しました。  
「無理にすべてを共通化しない」方針に切り替え、**画面ごとに最適な体験を優先**しています。

---

## 対応内容

### 1. ヘッダー構成の整理
- 共通ヘッダーの全面利用は行わず、
  - **ミートボールメニューのみ共通化**
  - 設定系画面は `shared/simple_header` を使用
- 画面タイトルはヘッダーで担い、本文側での重複した強調は削除

```erb
<%= render "shared/simple_header", title: "グループ設定" %>
