### PR TITLE
カスタムヘッダーを共通化

### DIFF
--- a/app/views/children/edit.html.erb
+++ b/app/views/children/edit.html.erb
@@ -2,20 +2,10 @@
 <% content_for :suppress_header, true %>
 
 <!-- カスタムヘッダー -->
-<div class="fixed top-0 left-0 w-full z-50 flex items-center justify-between bg-base-300 text-base-content px-4 py-3 border-b border-base-200">
-  <!-- 戻るボタン -->
-  <div class="w-20 flex-shrink-0">
-    <%= link_to "←", family_settings_path, class: "text-xl", aria: { label: "設定に戻る" } %>
-  </div>
-
-  <!-- タイトル -->
-  <h2 class="text-base font-bold text-center flex-grow truncate">
-    お子さま情報の編集
-  </h2>
-
-  <!-- 右端スペース確保 -->
-    <div class="w-20 flex-shrink-0"></div>
-  </div>
+<%= render "shared/back_header",
+      title: "お子さま情報の編集",
+      back_path: family_settings_path,
+      back_aria: "家族設定に戻る" %>
 
 <!-- 本体 -->
 <div class="max-w-xl mx-auto px-4 pt-16 pb-24 space-y-6">

--- a/app/views/children/new.html.erb
+++ b/app/views/children/new.html.erb
@@ -3,20 +3,10 @@
 <% content_for :suppress_header, true %>
 
 <!-- カスタムヘッダー -->
-<div class="fixed top-0 left-0 w-full z-50 flex items-center justify-between bg-base-300 text-base-content px-4 py-3 border-b border-base-200">
-  <!-- 戻るボタン -->
-  <div class="w-20 flex-shrink-0">
-    <%= link_to "←", family_settings_path, class: "text-xl", aria: { label: "家族設定に戻る" } %>
-  </div>
-
-  <!-- タイトル -->
-  <h2 class="text-base font-bold text-center flex-grow truncate">
-    お子さまの新規登録
-  </h2>
-
-  <!-- 右端スペース確保 -->
-    <div class="w-20 flex-shrink-0"></div>
-  </div>
+<%= render "shared/back_header",
+      title: "お子さまの新規登録",
+      back_path: family_settings_path,
+      back_aria: "家族設定に戻る" %>
 
 <!-- 本体 -->
 <div class="max-w-xl mx-auto px-4 pt-16 pb-24 space-y-6">

--- a/app/views/mypages/edit.html.erb
+++ b/app/views/mypages/edit.html.erb
@@ -3,21 +3,10 @@
 <% content_for :suppress_header, true %>
 
 <!-- カスタムヘッダー -->
-<div class="fixed top-0 left-0 w-full z-50 flex items-center justify-between bg-base-300 text-base-content px-4 py-3 border-b border-base-200">
-  <!-- 戻るボタン -->
-  <div class="w-20 flex-shrink-0">
-    <%= link_to "←", mypage_path, class: "text-xl", aria: { label: "マイページに戻る" } %>
-  </div>
-
-  <!-- タイトル -->
-  <h2 class="text-base font-bold text-center flex-grow truncate">
-    プロフィールの編集
-  </h2>
-
-  <!-- 右端スペース確保 -->
-    <div class="w-20 flex-shrink-0"></div>
-  </div>
-
+<%= render "shared/back_header",
+      title: "プロフィールの編集",
+      back_path: mypage_path,
+      back_aria: "マイページに戻る" %>
 
 
 <!-- 本体 -->

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -4,7 +4,14 @@
 <div class="relative min-h-screen">
 
   <!-- ===== ヘッダー ===== -->
-  <%= render "shared/simple_header", title: "マイページ" %>
+  <% if @user == current_user %>
+    <%= render "shared/simple_header", title: "マイページ" %>
+  <% else %>
+    <%= render "shared/back_header",
+          title: @user.name,
+          back_path: settings_family_group_path,
+          show_meatball: true %>
+  <% end %>
 
   <!-- ===== メインコンテンツ ===== -->
 <div class="mt-4 space-y-4 bg-base-100 rounded-2xl p-5 shadow-sm border border-base-200 mb-8">
@@ -32,7 +39,7 @@
 </div>
 
 <h2 class="text-sm font-semibold mb-3">
-  あなたの思い出
+  <%= @user == current_user ? "あなたの思い出" : "#{@user.name}の思い出" %>
 </h2>
 
 <div class="space-y-4  pb-24">

--- a/app/views/shared/_back_header.html.erb
+++ b/app/views/shared/_back_header.html.erb
@@ -1,0 +1,21 @@
+
+<%# locals: title:, back_path:, show_meatball: false %>
+
+<header class="w-full bg-base-300 shadow-sm px-4 h-14 flex items-center">
+  <!-- 戻るボタン -->
+  <div class="w-20 flex-shrink-0">
+    <%= link_to "←", back_path, class: "text-xl", aria: { label: "戻る" } %>
+  </div>
+
+  <!-- タイトル -->
+  <h2 class="text-base font-bold text-center flex-grow truncate">
+    <%= title %>
+  </h2>
+
+  <!-- 右側 -->
+  <div class="w-20 flex-shrink-0 flex justify-end">
+    <% if local_assigns[:show_meatball] %>
+      <%= render "shared/meatball_menu" %>
+    <% end %>
+  </div>
+</header>


### PR DESCRIPTION
## 概要

固定カスタムヘッダー（戻る＋中央タイトル）を共通パーシャル化し、各画面から流用しやすい形に統一しました。
これにより、画面ごとにヘッダーHTMLを重複して持たずに済み、タイトル・戻り先・右側メニューの有無を引数で切り替えられるようになりました。

### 変更内容
#### 1. 戻る＋中央タイトル用ヘッダーを共通化
- shared/_back_header.html.erb を新規作成
- title / back_path / back_aria / show_meatball を locals で受け取り可能に
- 右端は常に幅を確保し、中央タイトルがズレないように調整
- show_meatball: true の時のみミートボールメニューを表示できるよう対応
#### 2. 既存のカスタムヘッダー記述を render に置き換え
- 各ビューにベタ書きしていた固定ヘッダーを削除し、以下の形式に統一：
```erb
<% content_for :suppress_header, true %>

<%= render "shared/back_header",
      title: "お子さまの新規登録",
      back_path: family_settings_path,
      back_aria: "家族設定に戻る" %>
```