### PR TITLE
パスの修正

### DIFF
--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -9,7 +9,7 @@
   <% else %>
     <%= render "shared/back_header",
           title: @user.name,
-          back_path: settings_family_group_path,
+          back_path: family_settings_path,
           show_meatball: true %>
   <% end %>
 


### PR DESCRIPTION
## 背景
家族設定の「家族一覧」から 他ユーザーのページ に遷移した際、
本番環境で 500 Internal Server Error が発生。

ローカルでは再現せず、デプロイ後の画面確認で発覚。

## 原因
Render のログを確認した結果、以下のエラーが発生していた。
```erb
undefined local variable or method `settings_family_group_path'
```
mypages/show.html.erb にて
存在しないルートヘルパー settings_family_group_path を指定していた
実際のルートは family_settings_path
他ユーザーのページ表示時のみ、このコードパスを通るため 500 が発生

### 対応内容
- mypages/show.html.erb の戻りリンク指定を修正
