### PR TITLE
Fix backfill migration to avoid model enum evaluation

### DIFF
--- a/db/migrate/20260105100039_backfill_family_group_memberships.rb
+++ b/db/migrate/20260105100039_backfill_family_group_memberships.rb
@@ -1,12 +1,13 @@
 class BackfillFamilyGroupMemberships < ActiveRecord::Migration[7.2]
   def up
     say_with_time "Backfilling family_group_memberships from users.family_group_id" do
-      User.where.not(family_group_id: nil).find_each do |user|
-        FamilyGroupMembership.find_or_create_by!(
-          user_id: user.id,
-          family_group_id: user.family_group_id
-        )
-      end
+      execute <<~SQL
+        INSERT INTO family_group_memberships (user_id, family_group_id, created_at, updated_at)
+        SELECT id, family_group_id, NOW(), NOW()
+        FROM users
+        WHERE family_group_id IS NOT NULL
+        ON CONFLICT (user_id, family_group_id) DO NOTHING;
+      SQL
     end
   end
 


### PR DESCRIPTION
## 概要
Render デプロイ時に BackfillFamilyGroupMemberships が失敗する問題を修正。
FamilyGroupMembership の enum :role が DBカラム作成前に参照されて落ちるケースがあるため、モデル依存の backfill をやめて SQL ベースの backfill に変更し、本番の fresh DB でも確実に migration が通るようにした。

---

### 背景 / 発生していた問題
- Render の db:migrate 実行時に以下で失敗
- Undeclared attribute type for enum 'role' in FamilyGroupMembership
- 原因：backfill_family_group_memberships が migration 内で FamilyGroupMembership を呼び、
    enum :role の評価タイミングで role カラムが未作成（または schema の状態差）になり得たため

---

### 対応内容
- db/migrate/20260105100039_backfill_family_group_memberships.rb を修正
    - FamilyGroupMembership.find_or_create_by! 等の ActiveRecord / モデル呼び出しを廃止
    - SQL（INSERT…SELECT / ON CONFLICT）で backfill する方式に変更
    - 既存データがある環境でも二重作成しないように冪等性を確保

---

### 期待される効果
- 本番の fresh DB（初回 migrate）でも BackfillFamilyGroupMemberships が落ちない
- enum / モデル定義に依存しないため、migration の安全性が上がる
- デプロイ時の migration が安定する

---

### 動作確認
- [ ] docker compose exec web bin/rails db:migrate が正常終了すること
- [ ] Render でのデプロイ時 migration が正常終了すること