### PR TITLE
アルバム画面のモーダル表示と検索結果レイアウト崩れを改善

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -84,3 +84,12 @@
   min-height: 2.75rem;     /* ← 1行分は確保 */
   align-items: flex-start; /* ← 上寄せで複数行に対応 */
 }
+
+/* ====== すべての DaisyUI モーダルを最前面に出す ====== */
+.modal {
+  z-index: 9999 !important;
+}
+
+.modal-box {
+  z-index: 10000 !important;
+}

--- a/app/views/albums/_child_age_modal.html.erb
+++ b/app/views/albums/_child_age_modal.html.erb
@@ -1,8 +1,10 @@
+
 <!-- モーダルトグル -->
 <input type="checkbox" id="child-age-modal" class="modal-toggle" />
 
-<div class="modal">
-  <div class="modal-box max-w-md">
+<!-- ★ここも同じく z-[80] を追加 -->
+<div class="modal z-[9999]">
+  <div class="modal-box max-w-md relative z-[10000]">
     <h3 class="font-semibold text-base mb-2">子どもと年齢を選択</h3>
 
     <p class="text-xs text-base-content/60 mb-4">
@@ -24,14 +26,14 @@
       </select>
     </div>
 
-    <!-- 年齢（子どもに応じてJSが動的に中身を書き換える） -->
+    <!-- 年齢 -->
     <div class="mb-1">
       <label class="block text-sm font-semibold mb-1">年齢</label>
       <select
         class="select select-bordered w-full"
         data-child-age-target="ageSelect"
       >
-        <!-- connect/open で JS が「指定しない + 実データの年齢」を差し込む -->
+        <!-- JSで差し込む -->
       </select>
       <p class="text-xs opacity-70 mt-1">0歳＝0ヶ月以上〜1歳未満</p>
     </div>

--- a/app/views/albums/_person_tags_modal.html.erb
+++ b/app/views/albums/_person_tags_modal.html.erb
@@ -8,8 +8,9 @@
   data-action="change->person-tags#cancel"
 />
 
-<div class="modal">
-  <div class="modal-box max-w-md">
+<!-- ★ここに z-[80] を追加 -->
+<div class="modal z-[9999]">
+  <div class="modal-box max-w-md relative z-[10000]">
     <h3 class="font-semibold text-base mb-2">写っている人を選択</h3>
     <p class="text-xs text-base-content/60 mb-3">
       登録されているメンバーから選べます。

--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -12,7 +12,10 @@
         <%# いずれかの条件が入っていれば、検索エリアを開いた状態にする %>
         <input
           type="checkbox"
-          <%= (params[:year].present? || params[:child_id].present? || params[:age_years].present? || Array(params[:person_tag_ids]).present?) ? "checked" : "" %>
+          <%= (params[:year].present? ||
+               params[:child_id].present? ||
+               params[:age_years].present? ||
+               Array(params[:person_tag_ids]).present?) ? "checked" : "" %>
         />
 
         <div class="collapse-title text-sm font-semibold">
@@ -44,7 +47,11 @@
               <!-- ===== 年 ===== -->
               <div>
                 <label class="block text-sm font-semibold mb-1">年度（年）</label>
-                <select name="year" class="select select-bordered w-full" <%= "disabled" if age_mode %>>
+                <select
+                  name="year"
+                  class="select select-bordered w-full"
+                  <%= "disabled" if age_mode %>
+                >
                   <option value="">指定しない</option>
 
                   <%# 実データに存在する年だけ表示 %>
@@ -63,7 +70,7 @@
               </div>
 
               <%# ===== 誰が写ってる？（モーダル + チップ） ===== %>
-              <div data-controller="person-tags">
+              <div>
                 <div class="flex items-center justify-between mb-1 gap-2">
                   <span class="label font-medium text-base-content">誰が写っている？</span>
 
@@ -97,7 +104,9 @@
                       <span class="text-base-content/50">まだ選択されていません</span>
                     <% end %>
                   <% else %>
-                    <span class="text-base-content/50">タグを作成すると、ここに選択した名前が表示されます</span>
+                    <span class="text-base-content/50">
+                      タグを作成すると、ここに選択した名前が表示されます
+                    </span>
                   <% end %>
                 </div>
 
@@ -116,47 +125,53 @@
                     <% end %>
                   </div>
                 <% end %>
-
-                <%= render "albums/person_tags_modal", person_tags: @person_tags %>
               </div>
 
               <%# ===== 子ども年齢（モーダル + 表示 + hidden） ===== %>
-<div
-  data-controller="child-age"
-  data-child-age-ages-by-child-value="<%= @ages_by_child_id.to_json %>"
->
-  <div class="flex items-center justify-between mb-1 gap-2">
-    <span class="label font-medium text-base-content">子ども年齢</span>
+              <div>
+                <div class="flex items-center justify-between mb-1 gap-2">
+                  <span class="label font-medium text-base-content">子ども年齢</span>
 
-    <% if @children.any? %>
-      <label
-        for="child-age-modal"
-        class="btn btn-sm btn-outline normal-case"
-        data-action="click->child-age#open"
-      >
-        選択する
-      </label>
-    <% end %>
-  </div>
+                  <% if @children.any? %>
+                    <label
+                      for="child-age-modal"
+                      class="btn btn-sm btn-outline normal-case"
+                      data-action="click->child-age#open"
+                    >
+                      選択する
+                    </label>
+                  <% end %>
+                </div>
 
-  <div
-    class="input input-bordered input-auto-height w-full px-3 py-2"
-    data-child-age-target="selectedLabel"
-  >
-    <span class="text-base-content/50">まだ選択されていません</span>
-  </div>
+                <div
+                  class="input input-bordered input-auto-height w-full px-3 py-2"
+                  data-child-age-target="selectedLabel"
+                >
+                  <span class="text-base-content/50">まだ選択されていません</span>
+                </div>
 
-  <%# hidden（フォーム送信用） %>
-  <input type="hidden" name="child_id" value="<%= params[:child_id].to_s %>" data-child-age-target="childHidden" />
-  <input type="hidden" name="age_years" value="<%= params[:age_years].to_s %>" data-child-age-target="ageHidden" />
-
-  <%= render "albums/child_age_modal", children: @children %>
-</div>
+                <%# hidden（フォーム送信用） %>
+                <input
+                  type="hidden"
+                  name="child_id"
+                  value="<%= params[:child_id].to_s %>"
+                  data-child-age-target="childHidden"
+                />
+                <input
+                  type="hidden"
+                  name="age_years"
+                  value="<%= params[:age_years].to_s %>"
+                  data-child-age-target="ageHidden"
+                />
+              </div>
 
               <%# ===== 送信ボタン：Tsumugi仕様（左右50:50） ===== %>
               <div class="flex gap-3">
                 <%# 絞り込み：アクセント色（主ボタン） %>
-                <button type="submit" class="btn btn-accent flex-1 rounded-xl normal-case">
+                <button
+                  type="submit"
+                  class="btn btn-accent flex-1 rounded-xl normal-case"
+                >
                   絞り込む
                 </button>
 
@@ -178,7 +193,7 @@
       </div>
     </div>
 
-    <%# ===== 結果一覧 ===== %>
+    <%# ===== 結果一覧（※ここも max-w-xl の中！） ===== %>
     <% if @posts_by_year.present? %>
       <% @posts_by_year.each do |year, posts| %>
         <% if year == "撮影日未設定" %>
@@ -197,15 +212,22 @@
           </div>
         </div>
       <% end %>
-
-      <%# モーダル %>
-      <% @posts_by_year.each do |_, posts| %>
-        <% posts.each do |post| %>
-          <%= render "posts/modal", post: post %>
-        <% end %>
-      <% end %>
     <% else %>
       <%= render "albums/empty" %>
     <% end %>
-  </div>
-</div>
+  </div> <!-- /.max-w-xl -->
+</div>   <!-- /.min-h-screen -->
+
+<%# ==== アルバム一覧ページ専用モーダル（body 直下で描画） ==== %>
+<% content_for :modals do %>
+  <%= render "albums/person_tags_modal", person_tags: @person_tags if @person_tags.present? %>
+  <%= render "albums/child_age_modal",   children:    @children    if @children.present? %>
+
+  <% if @posts_by_year.present? %>
+    <% @posts_by_year.each do |_, posts| %>
+      <% posts.each do |post| %>
+        <%= render "posts/modal", post: post %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,52 +8,60 @@
     <%# Google FontsのMaterial Symbols Outlinedを読み込み %>
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
 
-    <%# SwiperのCSSを読み込み 画像スライダー（Swiper）の見た目を定義するCSS %>
+    <%# SwiperのCSS/JS %>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css" />
-    <%# SwiperのJavaScriptを読み込み 画像スライダー（Swiper）の動作を定義するJS %>
     <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>
 
     <title><%= content_for(:title) || "Tsumugi" %></title>
 
-    <%# ビューポートの設定とモバイル対応 %>
+    <%# ビューポート設定 %>
     <meta name="viewport" content="width=device-width,initial-scale=1">
 
     <%# iOSでWebアプリをホーム画面に追加した際のフルスクリーン表示を有効化 %>
     <meta name="mobile-web-app-capable" content="yes">
 
-    <%# フォーム送信時の「CSRF対策トークン」を <meta> に埋め込むヘルパー %>
-    <%# form_with などがここからトークンを読んで、安全にPOSTできるようになる %>
+    <%# CSRF/CSP %>
     <%= csrf_meta_tags %>
-
-    <%# コンテンツセキュリティポリシー（CSP）を設定するヘルパー %>
     <%= csp_meta_tag %>
 
     <%= yield :head %>
 
-    <%# PWA（スマホのホーム画面に追加するウェブアプリ）の設定ファイルを指定 %>
+    <%# PWA 設定 %>
     <link rel="manifest" href="/manifest.json">
 
-    <%# application.css と JavaScript のインクルード %>
+    <%# CSS / JS 読み込み %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
 
-  <%# bodyタグにdaisyUIのユーティリティクラスを適用 %>
+  <%#
+  body タグの役割：
+  - 画面全体のレイアウトと配色を司るルート要素
+  - Stimulus（person-tags / child-age）コントローラの親要素
+    → フィルターとモーダルをまたいだ状態管理を行う
+  - ページごとに背景色（transparent / base-100）を切り替える
+  - flex レイアウトでフッターナビを画面下に固定する
+%>
   <body
+    data-controller="person-tags child-age"
+    data-child-age-ages-by-child-value="<%= @ages_by_child_id.to_json if defined?(@ages_by_child_id) && @ages_by_child_id.present? %>"
     class="
       <%= content_for?(:transparent_background) ? 'bg-transparent' : 'bg-base-100' %>
       text-base-content min-h-screen flex flex-col
     "
   >
+
     <%# 共通ヘッダーを抑制するコンテンツが設定されていない場合にのみ表示 %>
     <%= render "shared/header" unless content_for(:suppress_header) == true %>
     <%= render "shared/flash" %>
 
-    <main>
+    <main class="flex-1">
       <%= yield %>
     </main>
 
     <%= render "shared/bottom_nav" if current_user %>
 
+    <%# 各ページが content_for :modals で渡したモーダルを body 直下に描画 %>
+    <%= yield :modals if content_for?(:modals) %>
   </body>
 </html>


### PR DESCRIPTION
## 概要
アルバム一覧ページにおける、モーダル表示と検索結果レイアウト崩れを改善しました。

## 対応内容

### 1. モーダル制御の改善
- Stimulus コントローラーの宣言場所を <body> に移動
  - person-tags
  - child-age
- モーダルを正しくコントロールできるように
  - data-child-age-ages-by-child-value を body へ移植
  - 各 modal 内の UI 操作が無効化されていた問題を解消

### 2.layout/application.html.erb の構造整理
```erb
<body
  data-controller="person-tags child-age"
  data-child-age-ages-by-child-value="…"
  class="
    bg-base-100 text-base-content min-h-screen flex flex-col
  "
>
```
- モーダル関連ロジックの導線を集約

### 3. アルバム一覧レイアウトの修正
- albums/index.html.erb 内の .max-w-xl コンテナの閉じタグ位置を調整
- 検索フォームと絞り込み結果を正しく同一レイヤー内に収めるよう修正

### 解消できた問題
- モーダル表示時にカードが前面に出てしまう問題を解決
- モーダル内 UI（タグ選択・子ども年齢選択）が正常に操作可能に
- スクロール・タップ操作が想定どおり動作

### 根本原因
- モーダルとカードが異なるスタッキングコンテキストに属しており、カード側が意図せず前面に表示されていた