### PR TITLE
LINE通知メッセージの投稿リンクボタンの改善

### DIFF
--- a/app/services/line_notifier.rb
+++ b/app/services/line_notifier.rb
@@ -2,6 +2,8 @@
 # LINE通知用のサービスクラス
 # ========================================
 class LineNotifier
+  include Rails.application.routes.url_helpers
+
   require 'net/http'
   require 'uri'
   require 'json'
@@ -118,8 +120,10 @@ class LineNotifier
     }
   end
 
-  def post_url(_post)
-    'https://tumugi.app/albums' # 必要に応じて詳細ページに変更
+  # 通知内の投稿URLを生成
+  def post_url(post)
+    # production環境のホスト名を使用
+    album_url(post.album)
   end
 
   def send_line_request(payload)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -36,4 +36,7 @@ Rails.application.configure do
 
   config.active_record.attributes_for_inspect = [ :id ]
 
+  # ActiveStorageのURL生成のために必要
+  Rails.application.routes.default_url_options[:host] = 'https://tumugi.app'
+
 end


### PR DESCRIPTION
## 概要
LINE通知メッセージの改修

### 変更点
- LineNotifier クラス内で以下を修正：
    - footer_button_section に投稿アルバムへのボタン (post_url) を追加
    - post_url(post) に album_url(post.album) を使用して投稿のアルバムページへ遷移可能にしました
### 対応済み
- production.rb にて Rails.application.routes.default_url_options[:host] を設定済みで、URL生成に問題なし

### エラーの原因（画像URL取得時のエラー修正）
- post.photos.first.image.service_url の使用による NoMethodError を修正しました。
- image は ActiveStorage::Attached::One であり、直接 service_url は呼び出せないため、blob.service_url に変更しました。
```ruby
post.photos.first&.image&.blob&.service_url
```