### PR TITLE
修正

### DIFF
--- a/app/services/line_notifier.rb
+++ b/app/services/line_notifier.rb
@@ -53,9 +53,12 @@ class LineNotifier
   end
 
   def hero_image_section(post)
+    photo = post.photos.first
+    image_url = (photo.image.blob&.service_url if photo&.image&.attached?)
+
     {
       type: 'image',
-      url: post.photos.first&.image&.blob&.service_url || placeholder_image_url,
+      url: image_url || placeholder_image_url,
       size: 'full',
       aspectRatio: '16:9',
       aspectMode: 'cover'


### PR DESCRIPTION
## 主な変更点
LINE通知でFlexメッセージを送信する際に使用していた以下のコード
```ruby
post.photos.first&.image&.service_url
```
が本番環境で以下のエラーを引き起こしたので：
```cpp
NoMethodError: undefined method `service_url` for #<ActiveStorage::Attached::One>
```
以下のように修正：
```
post.photos.first&.image&.blob&.service_url
```
- image は ActiveStorage::Attached::One オブジェクトで、service_url メソッドを持多ない。
- 画像URLを取得するには、image.blob.service_url とする必要がある。
- 今回の修正で、通知に含まれる画像が正しく表示されるようになり、エラーも解消される。