### PR TITLE
service_urlの変更

### DIFF
--- a/app/services/line_notifier.rb
+++ b/app/services/line_notifier.rb
@@ -54,11 +54,9 @@ class LineNotifier
 
   def hero_image_section(post)
     photo = post.photos.first
-  
+
     image_url =
-      if photo&.image&.attached?
-        Rails.application.routes.url_helpers.url_for(photo.image)
-      end
+      (Rails.application.routes.url_helpers.url_for(photo.image) if photo&.image&.attached?)
 
     {
       type: 'image',


### PR DESCRIPTION
## 主な変更点
service_urlの修正

### 起きていたエラー
```javascript
undefined method `service_url' for #<ActiveStorage::Blob>
```
ActiveStorageのBlobはservice_url を直接持っていないためurl_for(blob)を使用する必要がある。

修正前コード
```ruby
def hero_image_section(post)
  photo = post.photos.first
  image_url = if photo&.image&.attached?
                photo.image.blob&.service_url
              end

  {
    type: 'image',
    url: image_url || placeholder_image_url,
    size: 'full',
    aspectRatio: '16:9',
    aspectMode: 'cover'
  }
end
```


修正後コード
```ruby
def hero_image_section(post)
  photo = post.photos.first

  image_url =
    if photo&.image&.attached?
      Rails.application.routes.url_helpers.url_for(photo.image)
    end

  {
    type: 'image',
    url: image_url || placeholder_image_url,
    size: 'full',
    aspectRatio: '16:9',
    aspectMode: 'cover'
  }
end
```
