### PR TITLE
Fix: LINE通知のリンクをアルバム一覧へ戻す

### DIFF
--- a/app/services/line_notifier.rb
+++ b/app/services/line_notifier.rb
@@ -95,7 +95,7 @@ class LineNotifier
   def user_text(post)
     {
       type: 'text',
-      text: "#{post.user.name}さんが投稿しました",
+      text: "#{post.user.name}さんが思い出を投稿しました",
       size: 'sm',
       color: '#888888',
       wrap: true
@@ -112,13 +112,13 @@ class LineNotifier
     }
   end
 
-  def view_post_button(post)
+  def view_post_button(_post)
     {
       type: 'button',
       action: {
         type: 'uri',
-        label: '投稿を見る',
-        uri: post_url(post)
+        label: 'アルバムを開く',
+        uri: 'https://tumugi.app/albums'
       },
       style: 'link',
       height: 'sm'


### PR DESCRIPTION
### 主な変更点
LINE通知メッセージでの「投稿をみる」項目を「アルバムを開く」に変更しました。