### PR TITLE
person-tag_起動範囲の整理と警告解消（必要ページのみ有効化）

### DIFF
--- a/app/javascript/controllers/person_tags_controller.js
+++ b/app/javascript/controllers/person_tags_controller.js
@@ -7,6 +7,10 @@ export default class extends Controller {
   connect() {
     console.log("✅ person-tags controller connected")
 
+    // posts/edit など、targetが存在しない画面でも
+    // body起動されるためガード必須
+    if (!this.hasSelectedListTarget || !this.hasCheckboxTarget) return
+
     // 「確定済み」= hidden checkbox の状態
     this.committedIds = new Set(this.checkedIdsFromCheckboxes())
     // 「下書き」= モーダル内で一時的に選ぶ状態

--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -1,5 +1,7 @@
 <%# デフォルトヘッダー、デフォルト背景を制御 %>
 <% content_for :suppress_header, true %>
+<!-- ===== body controller 指定 ===== -->
+<% content_for :body_controllers, "person-tags" %>
 
 <div class="relative min-h-screen">
   <!-- ===== ヘッダー ===== -->

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,7 +43,7 @@
   - flex レイアウトでフッターナビを画面下に固定する
 %>
   <body
-    data-controller="person-tags"
+    data-controller="<%= yield(:body_controllers) if content_for?(:body_controllers) %>"
     class="
       <%= content_for?(:transparent_background) ? 'bg-transparent' : 'bg-base-100' %>
       text-base-content min-h-screen flex flex-col

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,5 +1,7 @@
 <!-- 投稿ページヘッダー抑制 -->
 <% content_for :suppress_header, true %>
+<!-- ===== body controller 指定 ===== -->
+<% content_for :body_controllers, "person-tags" %>
 
 <!-- 投稿ページカスタムヘッダー -->
 <div class="fixed top-0 left-0 w-full z-50 flex items-center justify-between

--- a/app/views/posts/_person_tags_field.html.erb
+++ b/app/views/posts/_person_tags_field.html.erb
@@ -1,6 +1,6 @@
 
 <% if @has_family_group %>
-  <div data-controller="person-tags" class="mb-4">
+  <div class="mb-4">
     <!-- ラベル＋ボタン行 -->
     <div class="flex items-center justify-between mb-1 gap-2">
       <%= f.label :person_tag_ids, "誰が写っている？",

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,5 +1,8 @@
 <!-- 編集ページヘッダー抑制 -->
 <% content_for :suppress_header, true %>
+<!-- ===== body controller 指定 ===== -->
+<% content_for :body_controllers, "person-tags" %>
+
 <!-- 編集ページカスタムヘッダー -->
 <div class="fixed top-0 left-0 w-full z-50 flex items-center justify-between bg-base-300 text-base-content px-4 py-3 border-b border-base-200">
   <!-- キャンセル（戻る）ボタン -->


### PR DESCRIPTION
## 概要

person-tags（「誰が写っている？」）のStimulus初期化範囲を整理し、
関係ない画面で発生していた警告（Missing target）を解消しました。

機能追加ではなく、既存機能の挙動は維持したまま、
必要な画面でのみ controller を有効化する形に整えています。

---

## 背景 / 課題

これまで `person-tags` が不要な画面でも初期化される構成になっており、
target が存在しない画面（思い出編集など）で以下の警告が発生していました。

- `Missing target element "selectedList" for "person-tags" controller`

---

## 対応内容

### 1. controller の起動をページ単位に限定
- `content_for :body_controllers` を用いて、必要なページでのみ `person-tags` を起動
- albums/index, posts/_form, posts/edit では `content_for :body_controllers, "person-tags"` を設定

### 2. person-tags controller にガードを追加
- 必須 target（selectedList/checkbox）が存在しない場合は処理を行わず return
- これにより、targetを持たない画面での警告を解消

