### PR TITLE
公開パス判定の不具合修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::Base
     '/contact',
     '/up',
     '/service-worker',
-    '/manifest'
+    '/manifest.json'
   ].freeze
 
   # ===== helper_method =====
@@ -174,7 +174,7 @@ class ApplicationController < ActionController::Base
 
   # LINE入場券認証関連
   def allow_public_path?
-    public_paths.include?(request.path)
+    PUBLIC_PATHS.include?(request.path)
   end
 
   # ブラウザ制限（rails標準の allow_browser を利用）


### PR DESCRIPTION
## 概要
以下の対応を行いました。
- 公開ページ判定ロジックの不具合により、ログイン前アクセスで 500 エラーが発生していた問題を修正

## 内容
### 公開ページ判定ロジックのバグ修正
修正前
```rb
def allow_public_path?
  public_paths.include?(request.path)
end
```
修正後
```rb
def allow_public_path?
  PUBLIC_PATHS.include?(request.path)
end
```
定数 PUBLIC_PATHS を参照すべきところで、
未定義の public_paths を参照していたため NameError → 500 エラー が発生していました。
本番デプロイ後に ログイン・トップページが開けなくなる不具合を解消するか確認します。
