### PR TITLE
/line/blocked が 406 Not Acceptable になる問題を修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -176,7 +176,4 @@ class ApplicationController < ActionController::Base
   def allow_public_path?
     PUBLIC_PATHS.include?(request.path)
   end
-
-  # ブラウザ制限（rails標準の allow_browser を利用）
-  allow_browser versions: :modern
 end

--- a/app/controllers/line_entry_controller.rb
+++ b/app/controllers/line_entry_controller.rb
@@ -1,7 +1,7 @@
 class LineEntryController < ApplicationController
   skip_before_action :require_line_entry
 
-  def show
+  def entry
     # ✅ リッチメニュー経由の「入場券」を付与
     session[:line_entry_verified] = true
     redirect_to root_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
 
   # LINE入口・ブロック
-  get "line/entry",   to: "line_entry#show"
+  get "line/entry",   to: "line_entry#entry"
   get "line/blocked", to: "line_entry#blocked"
 
   # LINEログイン


### PR DESCRIPTION
## 概要
初回アクセス時に `/line/blocked` が 406 Not Acceptable になる問題を修正しました。

## 発生していた問題
- 初回ユーザーがトップページにアクセス
- `require_line_entry` により `/line/blocked` へリダイレクト
- その `/line/blocked` が `allow_browser` により弾かれ、406 が返されていた

ログ例：
```
Processing by LineEntryController#blocked as HTML
Filter chain halted as ... allow_browser.rb:48 (lambda)
Completed 406 Not Acceptable
```

## 原因
Rails標準の `allow_browser versions: :modern` が
LINE内ブラウザ（WebView）や一部環境を許可対象外と判定し、
案内ページである `/line/blocked` の表示までブロックしていたため。

## 対応内容
- `allow_browser versions: :modern` を削除
- 初回ユーザーでも `/line/blocked` が正常に表示されるよう修正

## 確認する内容
- 外部ブラウザからの初回アクセスで `/line/blocked` が 200 で表示されること
- LINEリッチメニュー経由のアクセスに影響がないこと
- 406 Not Acceptable が発生しないこと
