### PR TITLE
URL生成のhost未設定でLINE通知が失敗する問題を修正

### DIFF
--- a/app/services/line_notifier.rb
+++ b/app/services/line_notifier.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # ========================================
 # LINE通知用のサービスクラス
 # ========================================
@@ -21,6 +23,16 @@ class LineNotifier
   end
 
   private
+
+  # ----------------------------------------
+  # URL生成のデフォルト（Service内でも *_url が落ちない保険）
+  # ----------------------------------------
+  def default_url_options
+    Rails.application.routes.default_url_options.presence || {
+      host: ENV.fetch('APP_HOST', 'tumugi.app'),
+      protocol: 'https'
+    }
+  end
 
   # ----------------------------------------
   # ペイロード全体を構築
@@ -48,29 +60,37 @@ class LineNotifier
       type: 'bubble',
       hero: hero_image_section(post),
       body: body_text_section(post),
-      footer: footer_button_section(post)
+      footer: footer_button_section
     }
   end
 
+  # ----------------------------------------
+  # Hero画像
+  # ----------------------------------------
   def hero_image_section(post)
-    photo = post.photos.first
-
-    image_url =
-      (Rails.application.routes.url_helpers.url_for(photo.image) if photo&.image&.attached?)
-
     {
       type: 'image',
-      url: image_url || placeholder_image_url,
+      url: hero_image_url(post),
       size: 'full',
       aspectRatio: '16:9',
       aspectMode: 'cover'
     }
   end
 
+  def hero_image_url(post)
+    photo = post.photos.first
+    return placeholder_image_url unless photo&.image&.attached?
+
+    rails_blob_url(photo.image) # host/protocol は default_url_options に任せる
+  end
+
   def placeholder_image_url
     'https://placehold.co/600x400?text=No+Image'
   end
 
+  # ----------------------------------------
+  # Body
+  # ----------------------------------------
   def body_text_section(post)
     {
       type: 'box',
@@ -102,35 +122,40 @@ class LineNotifier
     }
   end
 
-  def footer_button_section(post)
+  # ----------------------------------------
+  # Footer（ボタン）
+  # ----------------------------------------
+  def footer_button_section
     {
       type: 'box',
       layout: 'vertical',
       spacing: 'sm',
-      contents: [view_post_button(post)],
+      contents: [view_album_button],
       flex: 0
     }
   end
 
-  def view_post_button(_post)
+  def view_album_button
     {
       type: 'button',
       action: {
         type: 'uri',
         label: 'アルバムを開く',
-        uri: 'https://tumugi.app/albums'
+        uri: albums_url
       },
       style: 'link',
       height: 'sm'
     }
   end
 
-  # 通知内の投稿URLを生成
-  def post_url(post)
-    # production環境のホスト名を使用
-    Rails.application.routes.url_helpers.post_url(post, host: 'https://tumugi.app')
+  # （必要なら）通知内の投稿URL生成
+  def post_url_for(post)
+    post_url(post)
   end
 
+  # ----------------------------------------
+  # LINE API送信
+  # ----------------------------------------
   def send_line_request(payload)
     uri = URI.parse('https://api.line.me/v2/bot/message/push')
     http = Net::HTTP.new(uri.host, uri.port)
@@ -147,7 +172,7 @@ class LineNotifier
   def headers
     {
       'Content-Type' => 'application/json',
-      'Authorization' => "Bearer #{ENV.fetch('LINE_CHANNEL_ACCESS_TOKEN', nil)}"
+      'Authorization' => "Bearer #{ENV.fetch('LINE_CHANNEL_ACCESS_TOKEN')}"
     }
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support/core_ext/integer/time'
 
 Rails.application.configure do
@@ -5,12 +7,13 @@ Rails.application.configure do
 
   config.consider_all_requests_local = false
   config.action_controller.perform_caching = true
+
   config.assets.compile = false
   config.active_storage.service = :amazon
   config.force_ssl = true
 
   config.logger = ActiveSupport::Logger.new($stdout)
-    .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
+    .tap { |logger| logger.formatter = ::Logger::Formatter.new }
     .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
 
   config.log_tags = [:request_id]
@@ -23,18 +26,31 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
   config.active_record.attributes_for_inspect = [:id]
 
-  # ActiveStorage / *_url 生成のため
+  # ==================================================
+  # URL生成（*_url / ActiveStorage / LINE通知など）のための host 設定
+  # - APP_HOST は "tumugi.app"（https無し）を想定
+  # ==================================================
+  app_host = ENV.fetch('APP_HOST', 'tumugi.app')
+
+  # url_helpers.root_url などが参照するのは routes 側なのでここが重要
+  Rails.application.routes.default_url_options[:host] = app_host
+  Rails.application.routes.default_url_options[:protocol] = 'https'
+
+  # controller で url_for / rails_blob_url 等を生成する時のデフォルト
   config.action_controller.default_url_options = {
-    host: 'tumugi.app',
+    host: app_host,
     protocol: 'https'
   }
 
-  # メール内URL生成のため
+  # mailer 内で *_url を生成する時のデフォルト
   config.action_mailer.default_url_options = {
-    host: ENV.fetch('APP_HOST', 'tumugi.app'),
+    host: app_host,
     protocol: 'https'
   }
 
+  # ==================================================
+  # ActionMailer（SMTP）
+  # ==================================================
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
 


### PR DESCRIPTION
## 概要
投稿後に家族グループへ送るLINE通知が届かない事象を調査したところ、通知内で画像URL等を生成する際に host が未設定で Missing host to link to! が発生していました。
本PRでは、production環境で *_url / rails_blob_url が常に正しく生成できるように default_url_options を整備し、LINE通知のURL生成を安定化しました。

## 変更内容
### 1. config/environments/production.rb
- APP_HOST（https無し想定）を元に、URL生成に必要な設定を追加/整理
- Rails.application.routes.default_url_options[:host] / :protocol
- config.action_controller.default_url_options
- config.action_mailer.default_url_options
- production.rb は環境設定ファイルのため、クラス定義等の混在を避けて設定のみに整理

### 2. app/services/line_notifier.rb
- LineNotifier に default_url_options を追加し、Serviceクラス内でも *_url / rails_blob_url が落ちないように保険を追加
- Hero画像URL生成を rails_blob_url(photo.image) に統一（host/protocolは default_url_options に委譲）
- LINE APIヘッダの LINE_CHANNEL_ACCESS_TOKEN を ENV.fetch で必須化（設定漏れを早期検知）
- フッターボタンURLを albums_url に変更し、hostの直書きを削除

## 背景 / 原因

ログにて以下を確認：
- [LINE notify failed] ... ArgumentError: Missing host to link to!
- production console でも root_url 実行時に同様の Missing host が発生
→ routes.default_url_options にhostが設定されていない状態で *_url / rails_blob_url が呼ばれ、LINE通知処理が例外で失敗していた。
