### PR TITLE
招待経由で家族グループに参加した際のフラッシュメッセージを改善

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -130,6 +130,7 @@ class ApplicationController < ActionController::Base
 
     clear_invite_session!
     select_family_group!(family_group)
+    set_invite_join_flash!
     true
   end
 
@@ -138,6 +139,7 @@ class ApplicationController < ActionController::Base
     current_user.family_group_memberships.create!(family_group: family_group)
     clear_invite_session!
     select_family_group!(family_group)
+    set_invite_join_flash!
   end
 
   # 招待に関するセッション情報を削除する
@@ -183,5 +185,10 @@ class ApplicationController < ActionController::Base
     return true if path.start_with?('/invite/')
 
     false
+  end
+
+  # 招待参加が成立したときのフラッシュ（ログイン通知より優先したい）
+  def set_invite_join_flash!
+    flash.now[:notice] = t('flash.family_group.joined')
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -31,6 +31,7 @@ ja:
         failure: "家族グループの退会に失敗しました"
         no_member: "管理者が一人のため、家族グループを退会できません"
       last_admin_cannot_leave: "管理者が1人のため退出できません。"
+      joined: "家族グループに参加しました"
 
     member:
       invite:


### PR DESCRIPTION
## 概要
招待リンク経由でログインし、
家族グループへの参加が成立した場合にもかかわらず
「ログインしました」というメッセージが表示されていたため、
実際のユーザー体験に即したフラッシュメッセージに変更しました。

## 変更内容
- 招待経由で家族グループに参加できた場合、
    - フラッシュメッセージを
      「家族グループに参加しました。」 に変更
- 既存のログインフラッシュよりも
    招待参加の結果を優先して表示するように調整

## 実装方針
- ApplicationController の
    join_family_group_after_signup フロー内でフラッシュを上書き
- SessionsController 等の既存ロジックには手を加えず、
    影響範囲を最小限に抑えた実装
