### PR TITLE
招待リンク経由ログイン時のフラッシュメッセージ制御を整理

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -186,9 +186,4 @@ class ApplicationController < ActionController::Base
 
     false
   end
-
-  # 招待参加が成立したときのフラッシュ（ログイン通知より優先したい）
-  def set_invite_join_flash!
-    flash.now[:notice] = t('flash.family_group.joined')
-  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -89,7 +89,14 @@ class SessionsController < ApplicationController
   # 成功時のレスポンス
   # ============================================
   def login_success
-    redirect_to albums_path, notice: t('flash.login.success')
+    notice =
+      if session.delete(:invite_joined)
+        t('flash.family_group.joined')
+      else
+        t('flash.login.success')
+      end
+
+    redirect_to albums_path, notice: notice
   end
 
   # ============================================
@@ -158,6 +165,9 @@ class SessionsController < ApplicationController
     session[:current_family_group_id] = family_group.id
 
     Rails.logger.info "ユーザー#{user.id}をグループ#{family_group.id}に参加させました"
+
+    # 招待参加フラグ（ログイン成功メッセージより優先するため）
+    session[:invite_joined] = true
 
     # 招待リンクの処理は一度きりにする
     session.delete(:invite_family_group_id)


### PR DESCRIPTION
## 概要
招待リンク経由でログインし、家族グループに参加した場合の
フラッシュメッセージ制御を整理しました。

## 変更内容
- `ApplicationController` に追加していた `set_invite_join_flash!` を削除
- 招待参加の判定は `session` に委ね、ログイン完了時の分岐で表示メッセージを制御する方針に統一

## 背景
- 招待参加処理はリダイレクトを伴うため `flash.now` は適切でなかった
- `SessionsController#create` の `redirect_to` が最終的な通知責務を持つ方が自然

## 結果
- 招待参加フローとログインフローの責務が明確になった
- フラッシュメッセージが確実に表示されるようになった
- RuboCop に引っかからない構成になった
