### PR TITLE
LINE通知のアルバムリンクを /line/entry 経由にしてブロック画面を回避

### DIFF
--- a/app/controllers/line_entry_controller.rb
+++ b/app/controllers/line_entry_controller.rb
@@ -2,12 +2,24 @@ class LineEntryController < ApplicationController
   skip_before_action :require_line_entry
 
   def entry
-    # ✅ リッチメニュー経由の「入場券」を付与
+    # リッチメニュー経由の「入場券」を付与
     session[:line_entry_verified] = true
-    redirect_to root_path
+
+    next_path = safe_next_path(params[:next])
+    redirect_to(next_path || root_path)
   end
 
   def blocked
     # 案内ページを表示するだけ
+  end
+
+  private
+
+  # 外部URLへ飛ばないように安全チェック（オープンリダイレクト対策）
+  def safe_next_path(value)
+    return nil if value.blank?
+    return nil unless value.start_with?('/') # 相対パスのみ許可
+
+    value
   end
 end

--- a/app/services/line_notifier.rb
+++ b/app/services/line_notifier.rb
@@ -141,7 +141,7 @@ class LineNotifier
       action: {
         type: 'uri',
         label: 'アルバムを開く',
-        uri: albums_url
+        uri: line_entry_url(next: albums_path)
       },
       style: 'link',
       height: 'sm'


### PR DESCRIPTION
## 概要
LINE公式アカウントの通知メッセージからアルバムリンクを開いた際に
LINE入場券（session[:line_entry_verified]）が無くブロック画面になる問題を改善しました。

## 変更内容
- LineEntryController#entry を `next` パラメータに対応（安全な相対パスのみ許可）
  - 入場券付与後 `next || root` へリダイレクト
- LINE通知（LineNotifier）の「アルバムを開く」リンクを `albums_url` 直リンクから
  `/line/entry?next=/albums` 経由に変更

## 期待する挙動
LINE通知 → 「アルバムを開く」
→ /line/entry?next=/albums
→ 入場券付与
→ /albums に遷移
→ ブロック画面が表示されない

## 変更ファイル
- app/controllers/line_entry_controller.rb
- app/services/line_notifier.rb
