### PR TITLE
Rails のログが出力されない問題の切り分けと安定化対応

### DIFF
--- a/app/controllers/line_entry_controller.rb
+++ b/app/controllers/line_entry_controller.rb
@@ -2,6 +2,8 @@ class LineEntryController < ApplicationController
   skip_before_action :require_line_entry
 
   def entry
+    Rails.logger.warn("[LineEntry] entry called next=#{params[:next].inspect}")
+
     # リッチメニュー経由の「入場券」を付与
     session[:line_entry_verified] = true
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -32,3 +32,7 @@ plugin :tmp_restart
 # Specify the PID file. Defaults to tmp/pids/server.pid in development.
 # In other environments, only set the PID file if requested.
 pidfile ENV["PIDFILE"] if ENV["PIDFILE"]
+
+# バッファリングを無効化
+STDOUT.sync = true
+STDERR.sync = true


### PR DESCRIPTION
## 概要
Render 本番環境で Rails のログが出力されない問題の切り分けと安定化対応を行いました。
アプリ側・Puma 側の両方から STDOUT への確実なログ出力を保証し、
Render Logs に表示されない原因を特定できる状態にしています。

## 内容
### 1. 本番ログ確認用の一時ログを追加
- LineEntryController#entry に Rails.logger.warn を追加
- 本番環境で リクエストが確実に到達しているかを判別可能に
```rb
Rails.logger.warn("[LineEntry] entry called next=#{params[:next].inspect}")
```
※ 切り分け完了後は削除予定の一時ログ

### 2. Puma の STDOUT / STDERR バッファリング無効化
- config/puma.rb に以下を追加
- Render 環境で ログがバッファに溜まって表示されない問題を防止
```rb
STDOUT.sync = true
STDERR.sync = true
```
### 3. Render / production.rb 設定の整合性確認（コード変更なし）
- production.rb
    - logger は $stdout
    - log_level は ENV.fetch('RAILS_LOG_LEVEL', 'info')
- Render 環境変数
    - RAILS_ENV=production
    - RAILS_LOG_TO_STDOUT=true
👉 Rails 側のログ設計は正しいことを確認済み

## このPRの目的
- 「ログが出ない」原因が
  - Rails 側の問題か
  - Render の Runtime Logs / STDOUT 周りの問題か
を 確実に切り分けられる状態にすること

## 動作確認方法
### 1. 本番環境で以下にアクセス
```arduino
/line/entry?next=/
```
### 2. Render の Logs（Runtime / Last 1 hour / 検索なし）を確認
### 3. 以下ログが出ることを確認
```csharb
[LineEntry] entry called ...
```

### 補足
- Rails.logger.warn は 調査完了後に削除予定
- Puma の STDOUT.sync = true は 恒久対応として維持


