### PR TITLE
招待リンクURLのホストをAPP_HOSTで固定

### DIFF
--- a/app/controllers/invite_tokens_controller.rb
+++ b/app/controllers/invite_tokens_controller.rb
@@ -51,6 +51,8 @@ class InviteTokensController < ApplicationController
   # ・LINEで送信するためのURLを生成し、LINEトーク画面へ遷移
   #
   def create
+    Rails.logger.info("[InviteTokens#create] invite_url=#{invite_url_full}")
+
     family_group = invited_family_group
 
     # 招待対象のグループが取得できない場合
@@ -150,7 +152,11 @@ class InviteTokensController < ApplicationController
   # 招待URL生成
   # =========================
   def build_invite_url(invite)
-    invite_url(token: invite.token)
+    invite_url(
+      token: invite.token,
+      host: ENV.fetch('APP_HOST', 'tumugi.app'),
+      protocol: 'https'
+    )
   end
 
   # =========================
@@ -160,6 +166,14 @@ class InviteTokensController < ApplicationController
   # ・改行を含むため URLエンコード必須
   #
   def build_line_message(invite_url_full)
-    ERB::Util.url_encode("家族に参加してください🌿\n\n#{invite_url_full}")
+    ERB::Util.url_encode(
+      "Tsumugi（つむぎ）からの招待です🌿\n\n" \
+      "このリンクを開くと、\n" \
+      "家族グループに参加できます。\n\n" \
+      "はじめての方は、\n" \
+      "Tsumugi公式LINEアカウントを\n" \
+      "追加してからご利用ください 🐿️\n\n" \
+      "#{invite_url_full}"
+    )
   end
 end


### PR DESCRIPTION
## 概要
LINEで送信される招待リンクのホストが tsumugi.onrender.com になるケースがあったため、
招待URL生成時に APP_HOST を明示して tumugi.app を常に使用するように修正しました。
あわせて、デプロイ後の調査のため招待URLをログ出力します。

## 変更内容
- InviteTokensController#build_invite_url で invite_url 生成時に以下を明示
- host: ENV.fetch("APP_HOST", "tumugi.app")
- protocol: "https"
- 調査用に InviteTokensController#create で招待URLをログ出力（[InviteTokens#create] invite_url=...）

## 期待する挙動
- LINEに送られる招待リンクが常に https://tumugi.app/invite/:token になる
- Render Logs 上で招待URL生成結果を確認できる

## 動作確認（予定/確認手順）
1. 本番環境で招待リンクを発行する
2. Render Logs に [InviteTokens#create] invite_url=https://tumugi.app/invite/... が出ることを確認
3. その招待リンクをLINEで送信し、リンク先アクセス時の挙動（blocked → entry → login）を確認
