### PR TITLE
招待リンク処理の整理

### DIFF
--- a/app/controllers/invite_tokens_controller.rb
+++ b/app/controllers/invite_tokens_controller.rb
@@ -169,17 +169,17 @@ class InviteTokensController < ApplicationController
   def build_line_message(invite_url_full)
     text = <<~TEXT
       Tsumugi（つむぎ）からの招待です🌿
-  
+
       このリンクを開くと、
       家族グループに参加できます。
-  
+
       はじめての方は、
       Tsumugi公式LINEアカウントを
       追加してからご利用ください 🐿️
-  
+
       #{invite_url_full}
     TEXT
-  
+
     ERB::Util.url_encode(text)
   end
 end


### PR DESCRIPTION
## 概要
招待リンクをLINEで送信する際のメッセージ文言を、
Tsumugiを初めて利用するユーザーにも分かりやすい内容に改善しました。

## 背景
- 従来のメッセージでは、
- 何の招待リンクか
- 初回利用時に公式LINEアカウント追加が必要なこと
- が分かりづらく、初見ユーザーが迷う可能性がありました。

## 変更内容
- InviteTokensController#build_line_message の文言を改善
- 「Tsumugi（つむぎ）からの招待」であることを明示
- リンクの目的（家族グループへの参加）を明確化
- 初回利用時は公式LINEアカウント追加が必要な旨を案内