### PR TITLE
家族グループの確認項目の追加

### DIFF
--- a/app/concerns/admin/family_groups_admin.rb
+++ b/app/concerns/admin/family_groups_admin.rb
@@ -6,7 +6,7 @@ module Admin
 
         controller do
           def scoped_collection
-            super.includes(:users, :albums, :posts)
+            super.includes(:users, :albums, posts: %i[user photos])
           end
         end
 
@@ -30,10 +30,52 @@ module Admin
           attributes_table do
             row :id
             row :name
-            row('Users') { |fg| fg.users.size }
-            row('Posts') { |fg| fg.posts.size }
+            row('Users count') { |fg| fg.users.size }
+            row('Posts count') { |fg| fg.posts.size }
             row :created_at
             row :updated_at
+          end
+
+          panel 'Users in this Family Group' do
+            if resource.users.any?
+              table_for resource.users do
+                column :id
+                column :name
+                column :email
+                column :line_uid
+                column :role
+                column :created_at
+              end
+            else
+              para 'No users'
+            end
+          end
+
+          panel 'Posts in this Family Group' do
+            posts = resource.posts
+
+            if posts.any?
+              table_for posts.order(id: :desc) do
+                column :id do |post|
+                  # Posts の ActiveAdmin があれば詳細へ遷移（無ければID表示だけ）
+                  if respond_to?(:admin_post_path)
+                    link_to post.id, admin_post_path(post)
+                  else
+                    post.id
+                  end
+                end
+
+                column :status
+                column :photo_date
+                column :title
+                column('Album') { |post| post.album&.title }
+                column('User')  { |post| post.user&.name }
+                column('Photos') { |post| post.photos.length }
+                column :created_at
+              end
+            else
+              para 'No posts'
+            end
           end
         end
       end


### PR DESCRIPTION
## 概要
ActiveAdmin の FamilyGroup 管理画面 を拡張し、
ファミリーグループに どのユーザーが所属しているか、
どの投稿（Posts）が紐づいているか を詳細画面から確認できるようにしました。

## 実装内容
### 1. N+1 対策の強化
- scoped_collection にて以下を eager load
    - users
    - albums
    - posts（user, photos を含む）
- 管理画面表示時のクエリ数を最適化
```ruby
super.includes(:users, :albums, posts: %i[user photos])
```

### 2. FamilyGroup 一覧画面（index）
- 各ファミリーグループごとに以下を表示
  - ユーザー数
  - 投稿数
```ruby
column('Users') { |fg| fg.users.size }
column('Posts') { |fg| fg.posts.size }
```
