### PR TITLE
アルバム画面の思い出カードのUIの改善

### DIFF
--- a/app/assets/stylesheets/components/masking_tape.css
+++ b/app/assets/stylesheets/components/masking_tape.css
@@ -10,7 +10,31 @@
 }
 
   /* 色バリエーション */
-  .masking-tape--amber { background-color: #fde68a; }
-  .masking-tape--pink  { background-color: #fbcfe8; }
-  .masking-tape--mint  { background-color: #bbf7d0; }
-  .masking-tape--blue  { background-color: #bfdbfe; }
+  .masking-tape--amber    { background-color: #fde68a; }
+  .masking-tape--pink     { background-color: #fbcfe8; }
+  .masking-tape--mint     { background-color: #bbf7d0; }
+  .masking-tape--blue     { background-color: #bfdbfe; }
+  .masking-tape--lavender { background-color: #e9d5ff; }
+  .masking-tape--peach    { background-color: #fed7aa; }
+  .masking-tape--sage     { background-color: #d1fae5; }
+  .masking-tape--sky      { background-color: #e0f2fe; }
+  .masking-tape--lemon    { background-color: #fef9c3; }
+
+  /* テープの上に月名を印字 */
+  .masking-tape__text {
+    @apply flex items-center justify-center w-full h-full;
+    font-family: "Caveat", system-ui, sans-serif;
+    font-size: 0.6rem;
+    letter-spacing: 0.01em;
+  
+    color: rgba(0, 0, 0, 0.85);
+    line-height: 1;
+    user-select: none;
+    pointer-events: none;
+  
+    /* ✅ uppercase を殺す */
+    text-transform: none !important;
+  
+    /* 任意：印字感 */
+    text-shadow: 0 0.5px 0 rgba(255, 255, 255, 0.6);
+  }

--- a/app/assets/stylesheets/components/polaroid.css
+++ b/app/assets/stylesheets/components/polaroid.css
@@ -31,3 +31,50 @@
 .polaroid-caption {
   @apply pt-3 space-y-1;
 }
+
+/* ===== 付箋（Sticky Note） ===== */
+.sticky-note {
+  @apply absolute z-30 px-2 py-1 rounded-sm shadow-sm;
+}
+
+/* ===== 複数写真インジケータ（インスタ風マークのみ） ===== */
+.photo-count-label {
+  position: absolute;
+  right: 0.35rem;
+  bottom: 0.35rem;
+  z-index: 30;
+  pointer-events: none;
+
+  font-size: 10px;
+  line-height: 1;
+  padding: 2px 6px;
+  border-radius: 6px;
+
+  color: rgba(255, 255, 255, 0.95);
+  background: rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(2px);
+}
+
+/* マーク本体（□が重なったアイコン） */
+.multi-photo-icon::before,
+.multi-photo-icon::after {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 10px;
+  border: 1.6px solid rgba(255, 255, 255, 0.95);
+  border-radius: 3px;
+  background: rgba(0, 0, 0, 0.1);
+}
+
+/* 奥 */
+.multi-photo-icon::before {
+  top: 2px;
+  left: 2px;
+}
+
+/* 手前 */
+.multi-photo-icon::after {
+  top: 0;
+  left: 0;
+}

--- a/app/helpers/albums_helper.rb
+++ b/app/helpers/albums_helper.rb
@@ -1,9 +1,33 @@
 module AlbumsHelper
+  # アルバム一覧ページのヘッダタイトルを返す
   def album_index_header_title
     if current_family_group&.name.present?
       "#{current_family_group.name}のアルバム"
     else
       'アルバム'
     end
+  end
+
+  # マスキングテープのクラス一覧
+  MASKING_TAPE_CLASSES = %w[
+    masking-tape--amber
+    masking-tape--pink
+    masking-tape--mint
+    masking-tape--blue
+    masking-tape--lavender
+    masking-tape--peach
+    masking-tape--sage
+    masking-tape--sky
+    masking-tape--lemon
+  ].freeze
+
+  # マスキングテープのクラスをランダムに返す
+  def random_masking_tape_class
+    MASKING_TAPE_CLASSES.sample
+  end
+
+  # マスキングテープの回転角度をランダムに返す
+  def random_tape_rotation
+    rand(-15..15)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -34,19 +34,4 @@ module ApplicationHelper
       'bg-base-200 text-base-content'
     end
   end
-
-  # マスキングテープのクラスをランダムに返す
-  def random_masking_tape_class
-    %w[
-      masking-tape--amber
-      masking-tape--pink
-      masking-tape--mint
-      masking-tape--blue
-    ].sample
-  end
-
-  # マスキングテープの回転角度をランダムに返す
-  def random_tape_rotation
-    rand(-15..15)
-  end
 end

--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -242,9 +242,9 @@
     <% if @posts_by_year.present? %>
       <% @posts_by_year.each do |year, posts| %>
         <% if year.is_a?(String) %>
-          <h2 class="text-lg font-semibold mt-8 mb-4"><%= year %></h2>
+          <h2 class="text-lg font-semibold text-base-content/70 mt-4 mb-2"><%= year %></h2>
         <% else %>
-          <h2 class="text-lg font-semibold mt-8 mb-4"><%= year %>年</h2>
+          <h2 class="text-lg font-semibold text-base-content/70 mt-4 mb-2"><%= year %>年</h2>
         <% end %>
 
         <div class="relative mb-8">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,14 @@
     <%# Google FontsのMaterial Symbols Outlinedを読み込み %>
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet">
 
+    <%# Google Fonts: Amatic SC（付箋の月表示用） %>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Amatic+SC:wght@700&display=swap"
+      rel="stylesheet"
+    />
+
     <%# SwiperのCSS/JS %>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css" />
     <script src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js"></script>

--- a/app/views/postcard/_card.html.erb
+++ b/app/views/postcard/_card.html.erb
@@ -9,10 +9,22 @@
   <div
     class="masking-tape <%= random_masking_tape_class %>"
     style="transform: rotate(<%= random_tape_rotation %>deg);"
-  ></div>
+  >
+    <% if post.photo_date.present? %>
+      <span class="masking-tape__text">
+        <%= post.photo_date.strftime("%B").capitalize %>
+      </span>
+    <% end %>
+  </div>
 
   <!-- 写真 -->
-  <div class="polaroid-photo">
+  <div class="polaroid-photo relative">
+    <% if post.photos.size > 1 %>
+      <span class="photo-count-label" aria-label="photos <%= post.photos.size %>">
+        photos: <%= post.photos.size %>
+      </span>
+    <% end %>
+
     <% if post.photos.any? && post.photos.first.image.attached? %>
       <%= image_tag post.photos.first.image, class: "w-full h-full object-cover" %>
     <% else %>


### PR DESCRIPTION
## 概要（Summary）
アルバム一覧に表示される思い出カードについて、
撮影月を示すマスキングテープ表示の追加を中心に、
一覧画面の情報量・視認性・世界観を段階的に改善しました。

既存のポラロイド＋マスキングテープで、
年 → 月 → 思い出 の流れが直感的に把握できる UI になるよう調整しています。

また、複数枚写真の投稿にも対応し、
一覧画面から「写真が複数ある投稿」であることが分かるよう改善しています。

## 変更内容
### マスキングテープ（月表示）の追加
- 思い出カード（postcard/_card.html.erb）のマスキングテープ上に
- 撮影月（January / February …）を表示
- photo_date が存在する投稿のみ月名を表示
- 月名は 先頭のみ大文字＋以降小文字（January 形式）
### 複数写真投稿への対応
- 投稿に複数枚の写真が紐づいている場合のみ、
    一覧カード右下に photos: N を表示
- アイコンではなくテキスト表現にすることで、
    小画面でも視認性が高く、Tsumugiの雰囲気に合うUIに
### 実装整理・設計改善
- マスキングテープ関連のスタイルを masking_tape.css に集約
- アルバム専用の装飾ロジックを AlbumsHelper に切り出し、
    ApplicationHelper の責務を整理

## UI/UX 改善ポイント
- アルバム一覧で「いつの思い出か」が一目で分かる
- 年表示だけでは把握しづらかった 月単位の時間感覚を補完
- 複数写真の投稿であることが一覧から直感的に分かる

## 技術的なポイント
- マスキングテープ関連のスタイルは masking_tape.css に集約し、責務を明確化
