### PR TITLE
手動で実装確認（local3000アカウント）

### DIFF
--- a/app/services/line_notifier.rb
+++ b/app/services/line_notifier.rb
@@ -22,6 +22,23 @@ class LineNotifier
     send_line_request(payload)
   end
 
+  # ----------------------------------------
+  # LINEユーザーにテキストメッセージを送信
+  # ----------------------------------------
+  def push_text_message(to, text)
+    Rails.logger.info '=== LINE API 実行 (Text) ==='
+    Rails.logger.info "送信先: #{to}"
+
+    payload = {
+      to: to,
+      messages: [
+        { type: 'text', text: text }
+      ]
+    }
+
+    send_line_request(payload)
+  end
+
   private
 
   # ----------------------------------------
@@ -167,23 +184,6 @@ class LineNotifier
     response = http.request(request)
     Rails.logger.info "LINE API レスポンス: #{response.code} #{response.body}"
     response
-  end
-
-  # ----------------------------------------
-  # LINEユーザーにテキストメッセージを送信
-  # ----------------------------------------
-  def push_text_message(to, text)
-    Rails.logger.info '=== LINE API 実行 (Text) ==='
-    Rails.logger.info "送信先: #{to}"
-
-    payload = {
-      to: to,
-      messages: [
-        { type: 'text', text: text }
-      ]
-    }
-
-    send_line_request(payload)
   end
 
   def headers


### PR DESCRIPTION
## 概要
毎月1日に先月の思い出をLINEで通知する機能について、集計から送信までを行うサービスクラス群を実装しました。 また、実送信テストで判明した LineNotifier の可視性の問題を修正し、正常に送信できることを確認しました。

## 変更点
### 1. 機能実装（Serviceクラス）
月次通知を行うための以下のクラスを追加しました。

- MonthlyFamilySummary: 先月の投稿数や内訳（パパ・ママ・子供）を集計。
- LineMonthlySummaryMessageBuilder: 集計結果から通知用メッセージ（テキスト）を作成。
- MonthlySummaryNotifier: 個別グループに対して通知を実行するメインクラス。
- MonthlySummaryBatchNotifier: 全グループへの一括通知を行うための入り口（バッチ処理用）。

### 2. バグ修正
- LineNotifier: push_text_message メソッドが private になっていたため、外部から呼び出せるよう public に変更。

## 動作確認
ローカル環境のコンソール（rails runner）にて、特定グループ・特定月を指定して MonthlySummaryNotifier を実行し、以下の点を確認済み。
- 集計ロジックが正しく動作すること（ログ確認）。
- 対象のユーザー（パパ・ママ）が正しく特定されること。
- 実機（パパ）に対してLINE通知が届くこと。
     - ※ママ（ダミー垢）への送信エラーは想定通り。

## 補足
定期実行用のRakeタスク（スケジューラ登録用）は、次のブランチにて実装予定