### PR TITLE
月次通知機能の定期実行用Rakeタスク実装

### DIFF
--- a/lib/tasks/monthly_summary.rake
+++ b/lib/tasks/monthly_summary.rake
@@ -1,0 +1,30 @@
+namespace :monthly_summary do
+  desc '先月の思い出まとめをLINEで送信する（本番送信用）'
+  task send: :environment do
+    # ログを標準出力に出す（Renderのログで確認するため）
+    Rails.logger = Logger.new($stdout)
+
+    # デフォルトは「先月」
+    target_month = Date.current.prev_month
+
+    Rails.logger.info "=== [Batch Start] Monthly Summary for #{target_month.strftime('%Y-%m')} ==="
+
+    # バッチ実行（dry_run: false で本番送信）
+    MonthlySummaryBatchNotifier.call(month: target_month, dry_run: false)
+
+    Rails.logger.info '=== [Batch End] ==='
+  end
+
+  desc '【テスト用】先月の思い出まとめ送信のドライラン（送信なし・ログのみ）'
+  task dry_run: :environment do
+    Rails.logger = Logger.new($stdout)
+    target_month = Date.current.prev_month
+
+    Rails.logger.info '=== [Dry Run Start] ==='
+
+    # dry_run: true なので送信されません
+    MonthlySummaryBatchNotifier.call(month: target_month, dry_run: true)
+
+    Rails.logger.info '=== [Dry Run End] ==='
+  end
+end


### PR DESCRIPTION
## 概要
実装済みの月次通知機能（BatchNotifier）を、RenderのCron Job（スケジューラ）から毎月自動実行できるようにするための Rakeタスクを追加しました。

## 変更点
- Rakeタスクの追加 (lib/tasks/monthly_summary.rake)
    - rake monthly_summary:send
        - 本番送信用タスク。dry_run: false でバッチ処理を呼び出し、実際にLINE送信を行います。
        - 毎月1日の定期実行で使用します。
    - rake monthly_summary:dry_run
        - テスト用タスク。dry_run: true で呼び出し、送信を行わずに集計ログのみを出力します。

## 動作確認
ローカル環境にて以下のコマンドを実行し、全グループに対してDryRunが完走すること（ログ出力）を確認済み。
```bash
docker compose exec web bundle exec rake monthly_summary:dry_run
```
